### PR TITLE
Fix Drop Frame bug

### DIFF
--- a/lib/drop_frame.ex
+++ b/lib/drop_frame.ex
@@ -10,27 +10,27 @@ defmodule Vtc.Private.DropFrame do
   # https://www.davidheidelberger.com/2010/06/10/drop-frame-timecode/
   @spec parse_adjustment(Timecode.Sections.t(), Framerate.t()) ::
           {:ok, integer()} | {:error, Timecode.ParseError.t()}
-
   def parse_adjustment(sections, %Framerate{ntsc: :drop} = rate) do
     drop_rate = frames_dropped_per_minute(rate)
 
     with :ok <- parse_adjustment_validate(sections, drop_rate) do
       total_minutes = 60 * sections.hours + sections.minutes
-      adjustment = drop_rate * (total_minutes - div(total_minutes, 10))
+      adjustment = round(drop_rate * (total_minutes - div(total_minutes, 10)))
       {:ok, -adjustment}
     end
   end
 
   def parse_adjustment(_, _), do: {:ok, 0}
 
+  # Validates that the frame value from our string is not a frame that should have been
+  # skipped on a non-tenth minute.s
   @spec parse_adjustment_validate(Timecode.Sections.t(), integer()) ::
           :ok | {:error, Timecode.ParseError.t()}
   defp parse_adjustment_validate(sections, drop_rate) do
-    tenth_minute? = match?({_, 0}, Rational.divmod(sections.minutes, 10))
+    tenth_minute? = rem(sections.minutes, 10) == 0
+    minute_boundary? = sections.seconds == 0
 
-    # We have a bad frame value if our frames place is less than the drop_frames we
-    # are supposed to skip.
-    if sections.frames < drop_rate and not tenth_minute? do
+    if sections.frames < drop_rate and not tenth_minute? and minute_boundary? do
       {:error, %Timecode.ParseError{reason: :bad_drop_frames}}
     else
       :ok
@@ -42,55 +42,38 @@ defmodule Vtc.Private.DropFrame do
   # Algorithm adapted from:
   # https://www.davidheidelberger.com/2010/06/10/drop-frame-timecode/
   @spec frame_num_adjustment(integer(), Framerate.t()) :: integer()
-  def frame_num_adjustment(frame_number, rate) do
-    timebase = Framerate.timebase(rate)
-    drop_rate = frames_dropped_per_minute(rate)
+  def frame_num_adjustment(frame_number, %Framerate{ntsc: :drop} = rate) do
+    framerate = Ratio.to_float(rate.playback)
 
-    # Get the number frames-per-minute at the whole-frame rate
-    frames_per_minute_whole = Ratio.mult(timebase, 60)
-    # Get the number of frames are in a minute where we have dropped frames at the
-    # beginning
-    frames_per_minute_with_drop = Ratio.sub(frames_per_minute_whole, drop_rate)
+    dropped_per_min = round(framerate * 0.066666)
+    frames_per_hour = round(framerate * 60 * 60)
+    frames_per_24_hours = frames_per_hour * 24
+    frames_per_10_min = round(framerate * 60 * 10)
+    frames_per_min = round(framerate) * 60 - dropped_per_min
 
-    # Get the number of actual frames in a 10-minute span for drop frame timecode. Since
-    # we drop 9 times a minute, it will be 9 drop-minute frame counts + 1 whole-minute
-    # frame count.
-    frames_per_10_minutes_drop =
-      frames_per_minute_with_drop |> Ratio.mult(9) |> Ratio.add(frames_per_minute_whole)
+    frame_number = rem(frame_number, frames_per_24_hours)
 
-    # Get the number of 10s of minutes in this count, and the remaining frames.
-    {tens_of_minutes, frames} = Rational.divmod(frame_number, frames_per_10_minutes_drop)
+    tens_of_mins = div(frame_number, frames_per_10_min)
+    remaining_mins = rem(frame_number, frames_per_10_min)
 
-    # Create an adjustment for the number of 10s of minutes. It will be 9 times the
-    # drop value (we drop for the first 9 minutes, then leave the 10th alone).
-    adjustment = 9 |> Ratio.mult(drop_rate) |> Ratio.mult(tens_of_minutes)
+    tens_of_mins_adjustment = dropped_per_min * 9 * tens_of_mins
 
-    # If our remaining frames are less than a whole minute, we aren't going to drop
-    # again. Add the adjustment and return.
-    if Ratio.compare(frames, frames_per_minute_whole) == :lt do
-      Ratio.add(frame_number, adjustment)
+    if remaining_mins > dropped_per_min do
+      remaining_minutes_adjustment =
+        dropped_per_min * div(remaining_mins - dropped_per_min, frames_per_min)
+
+      tens_of_mins_adjustment + remaining_minutes_adjustment
     else
-      # Remove the first full minute (we don't drop until the next minute) and add the
-      # drop-rate to the adjustment.
-      frames = Ratio.sub(frames, timebase)
-      adjustment = Ratio.add(adjustment, drop_rate)
-
-      # Get the number of remaining drop-minutes present, and add a drop adjustment for
-      # each.
-      minutes_drop = frames |> Ratio.div(frames_per_minute_with_drop) |> Ratio.floor()
-      adjustment = minutes_drop |> Ratio.mult(drop_rate) |> Ratio.add(adjustment)
-
-      # Return our original frame number adjusted by our calculated adjustment.
-      Ratio.add(frame_number, adjustment)
+      tens_of_mins_adjustment
     end
   end
+
+  def frame_num_adjustment(_, _), do: 0
 
   # Get the number of frames that need to be dropped per minute (minus the 10th miute).
   @spec frames_dropped_per_minute(Framerate.t()) :: integer()
   defp frames_dropped_per_minute(rate) do
-    rate
-    |> Framerate.timebase()
-    |> Ratio.mult(Ratio.new(0.066666, 1))
-    |> Rational.round()
+    time_base = rate |> Framerate.timebase() |> Rational.round()
+    round(time_base * 0.066666)
   end
 end

--- a/lib/timcode.ex
+++ b/lib/timcode.ex
@@ -289,7 +289,13 @@ defmodule Vtc.Timecode do
       timecode
       |> frames()
       |> abs()
-      |> then(&if rate.ntsc == :drop, do: DropFrame.frame_num_adjustment(&1, rate), else: &1)
+
+    total_frames =
+      if rate.ntsc == :drop do
+        total_frames + DropFrame.frame_num_adjustment(total_frames, rate)
+      else
+        total_frames
+      end
 
     {hours, remainder} = Rational.divmod(total_frames, frames_per_hour)
     {minutes, remainder} = Rational.divmod(remainder, frames_per_minute)

--- a/test/timecode_test.exs
+++ b/test/timecode_test.exs
@@ -159,6 +159,25 @@ defmodule Vtc.TimecodeTest do
       feet_and_frames: "0+00"
     },
     %TcParseCase{
+      name: "00:01:01;00 29.97 Drop-Frame",
+      rate: Rates.f29_97_df(),
+      seconds_inputs: [
+        Ratio.new(457_457, 7500),
+        "00:01:00.994266667"
+      ],
+      frames_inputs: [
+        1828,
+        "00:01:01;00",
+        "114+04"
+      ],
+      seconds: Ratio.new(457_457, 7500),
+      frames: 1828,
+      timecode: "00:01:01;00",
+      runtime: "00:01:00.994266667",
+      premiere_ticks: 15_493_519_641_600,
+      feet_and_frames: "114+04"
+    },
+    %TcParseCase{
       name: "00:00:02;02 29.97 Drop-Frame",
       rate: Rates.f29_97_df(),
       seconds_inputs: [
@@ -577,7 +596,7 @@ defmodule Vtc.TimecodeTest do
   end
 
   describe "#timecode/1" do
-    for test_case <- @parse_cases do
+    for {test_case, case_index} <- Enum.with_index(@parse_cases) do
       @test_case test_case
       @input_struct %Timecode{seconds: @test_case.seconds, rate: @test_case.rate}
 
@@ -587,11 +606,13 @@ defmodule Vtc.TimecodeTest do
         rate: @test_case_negative.rate
       }
 
-      test "#{@test_case.name}" do
+      @tag case: :"timecode_#{case_index}"
+      test "#{@test_case.name} | #{case_index}" do
         assert Timecode.timecode(@input_struct) == @test_case.timecode
       end
 
-      test "#{@test_case.name} | negative" do
+      @tag case: :"timecode_#{case_index}_negative"
+      test "#{@test_case.name} | #{case_index} | negative" do
         assert Timecode.timecode(@input_struct_negative) == @test_case_negative.timecode
       end
     end


### PR DESCRIPTION
Fixes bug with both parsing and rendering drop frame.

Parsing bug is described from a similar bug afflicting all vtc repos [here](https://github.com/opencinemac/vtc-py/pull/15) and [here](https://github.com/opencinemac/vtc-rs).

The rendering bug was a result of using rational math in place of float math.