### PR TITLE
[Docs] Better docs and runtime options

### DIFF
--- a/lib/framerate.ex
+++ b/lib/framerate.ex
@@ -48,6 +48,7 @@ defmodule Vtc.Framerate do
   """
   @type t :: %__MODULE__{playback: Ratio.t(), ntsc: ntsc()}
 
+  @doc section: :inspect
   @doc """
   The rational representation of the timecode's 'logical speed'.
 
@@ -57,6 +58,7 @@ defmodule Vtc.Framerate do
   def timebase(%{ntsc: nil} = framerate), do: framerate.playback
   def timebase(framerate), do: framerate.playback |> Rational.round() |> Ratio.new()
 
+  @doc section: :inspect
   @doc """
   Returns true if the value represents and NTSC framerate.
 
@@ -77,6 +79,7 @@ defmodule Vtc.Framerate do
   """
   @type new_opts() :: [ntsc: ntsc(), invert?: boolean()]
 
+  @doc section: :parse
   @doc """
   Creates a new Framerate with a playback speed or timebase.
 
@@ -125,6 +128,7 @@ defmodule Vtc.Framerate do
 
   def new(rate, opts), do: new_core(rate, opts)
 
+  @doc section: :parse
   @doc """
   As `new/2` but raises an error instead.
   """

--- a/lib/range.ex
+++ b/lib/range.ex
@@ -41,6 +41,7 @@ defmodule Vtc.Range do
   @enforce_keys [:in, :out, :out_type]
   defstruct [:in, :out, :out_type]
 
+  @doc section: :parse
   @doc """
   Creates a new `Range`.
 
@@ -97,6 +98,7 @@ defmodule Vtc.Range do
     end
   end
 
+  @doc section: :parse
   @doc """
   As `new/3`, but raises on error.
   """
@@ -122,6 +124,7 @@ defmodule Vtc.Range do
     end
   end
 
+  @doc section: :parse
   @doc """
   Returns a range with an `:in` value of `tc_in` and a duration of `duration`.
 
@@ -181,6 +184,7 @@ defmodule Vtc.Range do
     end
   end
 
+  @doc section: :parse
   @doc """
   As with_duration/3, but raises on error.
   """
@@ -208,6 +212,7 @@ defmodule Vtc.Range do
   defp validate_rates_equal(_, _, a_name, b_name),
     do: {:error, ArgumentError.exception("`#{a_name}` and `#{b_name}` must have same `rate`")}
 
+  @doc section: :manipulate
   @doc """
   Adjusts range to have an inclusive out timecode.
 
@@ -228,6 +233,7 @@ defmodule Vtc.Range do
     %__MODULE__{range | out: new_out, out_type: :inclusive}
   end
 
+  @doc section: :manipulate
   @doc """
   Adjusts range to have an exclusive out timecode.
 
@@ -253,6 +259,7 @@ defmodule Vtc.Range do
   defp adjust_out_exclusive(tc, :exclusive), do: tc
   defp adjust_out_exclusive(tc, :inclusive), do: Timecode.add(tc, 1, round: :off)
 
+  @doc section: :inspect
   @doc """
   Returns the duration in `Vtc.Timecode` of `range`.
 
@@ -271,6 +278,7 @@ defmodule Vtc.Range do
     Timecode.sub(out_tc, in_tc)
   end
 
+  @doc section: :compare
   @doc """
   Returns `true` if there is overlap between `a` and `b`.
 
@@ -315,6 +323,7 @@ defmodule Vtc.Range do
     end
   end
 
+  @doc section: :compare
   @doc """
   Returns the the range where `a` and `b` overlap/intersect.
 
@@ -348,6 +357,7 @@ defmodule Vtc.Range do
   @spec intersection(t(), t()) :: {:ok, t()} | {:error, :none}
   def intersection(a, b), do: calc_overlap(a, b, &overlaps?(&1, &2))
 
+  @doc section: :compare
   @doc """
   As `intersection`, but returns a Range from `00:00:00:00` - `00:00:00:00` when there
   is no overlap.
@@ -374,6 +384,7 @@ defmodule Vtc.Range do
     end
   end
 
+  @doc section: :compare
   @doc """
   Returns the range between two, non-overlapping ranges.
 
@@ -407,6 +418,7 @@ defmodule Vtc.Range do
   @spec separation(t(), t()) :: {:ok, t()} | {:error, :none}
   def separation(a, b), do: calc_overlap(a, b, &(not overlaps?(&1, &2)))
 
+  @doc section: :compare
   @doc """
   As `separation`, but returns a Range from `00:00:00:00` - `00:00:00:00` when there
   is overlap.

--- a/lib/sources/frames.ex
+++ b/lib/sources/frames.ex
@@ -8,11 +8,17 @@ defprotocol Vtc.Source.Frames do
   Out of the box, this protocol is implemented for the following types:
 
   - `Integer`
-  - `String` & 'BitString'
+
+  - `String` & `BitString`
+
     - timecode ("01:00:00:00")
+
     - integer ("86400")
+
     - Feet+Frames ("5400+00")
+
   - `Vtc.Source.Frames.TimecodeStr`
+
   - `Vtc.Source.Frames.FeetAndFrames`
   """
 

--- a/lib/timcode.ex
+++ b/lib/timcode.ex
@@ -958,8 +958,8 @@ defmodule Vtc.Timecode do
   '00:59:59.9964', and <01:00:00:00 <23.98 NTSC>> has a true runtime of
   '01:00:03.6'
   """
-  @spec runtime(t(), integer()) :: String.t()
-  def runtime(timecode, precision \\ 9), do: timecode |> RuntimeStr.from_timecode(precision) |> then(& &1.in)
+  @spec runtime(t(), precision: non_neg_integer(), trim_zeros?: boolean()) :: String.t()
+  def runtime(timecode, opts \\ []), do: timecode |> RuntimeStr.from_timecode(opts) |> then(& &1.in)
 
   @doc """
   Returns the number of elapsed ticks `timecode` represents in Adobe Premiere Pro.

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,14 @@ defmodule Vtc.MixProject do
           "Frames Formats": [Frames.FeetAndFrames, Frames.TimecodeStr],
           "Seconds Formats": [Seconds.PremiereTicks, Seconds.RuntimeStr],
           "Source Protocols": [Seconds, Frames]
+        ],
+        groups_for_docs: [
+          Parse: &(&1[:section] == :parse),
+          Manipulate: &(&1[:section] == :manipulate),
+          Inspect: &(&1[:section] == :inspect),
+          Compare: &(&1[:section] == :compare),
+          Arithmatic: &(&1[:section] == :arithmatic),
+          Convert: &(&1[:section] == :convert)
         ]
       ],
       build_embedded: Mix.env() == :prod,

--- a/test/timecode/timecode_parse_test.exs
+++ b/test/timecode/timecode_parse_test.exs
@@ -889,14 +889,6 @@ defmodule Vtc.TimecodeTest.Parse do
         %{seconds: seconds, runtime: runtime, rate: rate} = context
         input = %Timecode{seconds: seconds, rate: rate}
 
-        assert Timecode.runtime(input, 9) == runtime
-      end
-
-      @tag test_case: test_case
-      test "#{test_case.name} | precision 9 default", context do
-        %{seconds: seconds, runtime: runtime, rate: rate} = context
-        input = %Timecode{seconds: seconds, rate: rate}
-
         assert Timecode.runtime(input) == runtime
       end
 
@@ -905,8 +897,41 @@ defmodule Vtc.TimecodeTest.Parse do
         %{seconds: seconds, runtime: runtime, rate: rate} = context
         input = %Timecode{seconds: seconds, rate: rate}
 
-        assert Timecode.runtime(input, 9) == runtime
+        assert Timecode.runtime(input) == runtime
       end
+    end
+
+    test ":precision respected" do
+      input = %Timecode{seconds: Ratio.new(2_008_629_623, 24_000), rate: Rates.f23_98()}
+
+      assert Timecode.runtime(input, precision: 9) == "23:14:52.900958333"
+      assert Timecode.runtime(input, precision: 8) == "23:14:52.90095833"
+      assert Timecode.runtime(input, precision: 7) == "23:14:52.9009583"
+      assert Timecode.runtime(input, precision: 6) == "23:14:52.900958"
+      assert Timecode.runtime(input, precision: 5) == "23:14:52.90096"
+      assert Timecode.runtime(input, precision: 4) == "23:14:52.901"
+      assert Timecode.runtime(input, precision: 3) == "23:14:52.901"
+      assert Timecode.runtime(input, precision: 2) == "23:14:52.9"
+      assert Timecode.runtime(input, precision: 1) == "23:14:52.9"
+    end
+
+    test "trim_zeros?: false" do
+      input = %Timecode{seconds: Ratio.new(0), rate: Rates.f23_98()}
+      assert Timecode.runtime(input, trim_zeros?: false) == "00:00:00.000000000"
+    end
+
+    test "trim_zeros?: false, :precision respected" do
+      input = %Timecode{seconds: Ratio.new(2_008_629_623, 24_000), rate: Rates.f23_98()}
+
+      assert Timecode.runtime(input, precision: 9, trim_zeros?: false) == "23:14:52.900958333"
+      assert Timecode.runtime(input, precision: 8, trim_zeros?: false) == "23:14:52.90095833"
+      assert Timecode.runtime(input, precision: 7, trim_zeros?: false) == "23:14:52.9009583"
+      assert Timecode.runtime(input, precision: 6, trim_zeros?: false) == "23:14:52.900958"
+      assert Timecode.runtime(input, precision: 5, trim_zeros?: false) == "23:14:52.90096"
+      assert Timecode.runtime(input, precision: 4, trim_zeros?: false) == "23:14:52.9010"
+      assert Timecode.runtime(input, precision: 3, trim_zeros?: false) == "23:14:52.901"
+      assert Timecode.runtime(input, precision: 2, trim_zeros?: false) == "23:14:52.90"
+      assert Timecode.runtime(input, precision: 1, trim_zeros?: false) == "23:14:52.9"
     end
   end
 
@@ -1245,7 +1270,7 @@ defmodule Vtc.TimecodeTest.Parse do
         %{val_in: val_in, expected: expected} = context
 
         parsed = Timecode.with_seconds!(val_in, Rates.f24())
-        assert expected == Timecode.runtime(parsed, 9)
+        assert expected == Timecode.runtime(parsed)
       end
     end
   end


### PR DESCRIPTION
- Convert runtime options to `opts \\ []` instead of default args.
- Organize Module functions for Core API
- More examples and overall more streamlined documentation