### PR TITLE
[Feature] Add `:coerce_ntsc?` to `Framerate.new/2`

### DIFF
--- a/lib/framerate_parse_error.ex
+++ b/lib/framerate_parse_error.ex
@@ -30,7 +30,7 @@ defmodule Vtc.Framerate.ParseError do
   Type of `ParseError`
   """
   @type t() :: %__MODULE__{
-          reason: :bad_drop_rate | :invalid_ntsc | :unrecognized_format | :imprecise
+          reason: :bad_drop_rate | :invalid_ntsc | :invalid_ntsc_rate | :unrecognized_format | :imprecise
         }
 
   @doc """
@@ -39,6 +39,7 @@ defmodule Vtc.Framerate.ParseError do
   @spec message(t()) :: String.t()
   def message(%{reason: :bad_drop_rate}), do: "drop-frame rates must be divisible by 30000/1001"
   def message(%{reason: :invalid_ntsc}), do: "ntsc is not a valid atom. must be :non_drop, :drop, or nil"
+  def message(%{reason: :invalid_ntsc_rate}), do: "NTSC rates must be divisible by 1001 when :coerce_ntsc? is false"
   def message(%{reason: :unrecognized_format}), do: "framerate string format not recognized"
   def message(%{reason: :imprecise}), do: "non-whole floats are not precise enough to create a non-NTSC Framerate"
 end

--- a/lib/timcode.ex
+++ b/lib/timcode.ex
@@ -875,8 +875,8 @@ defmodule Vtc.Timecode do
   "<01:45:00:00 <23.98 NTSC>>"
   ```
 
-  `ntsc: :non_drop` is assumed by default, but you can set a different value with the
-  `:ntsc` option:
+  `ntsc: :non_drop, coerce_ntsc?: true` is assumed by default, but you can set a
+  different value with the `:ntsc` option:
 
   ```elixir
   iex> result =

--- a/lib/timecode_eval.ex
+++ b/lib/timecode_eval.ex
@@ -111,7 +111,11 @@ defmodule Vtc.Timecode.Eval do
   @spec setup_rate(Framerate.t() | number() | Ratio.t() | nil, ntsc: Framerate.ntsc()) :: Framerate.t() | nil
   def setup_rate(nil, _), do: nil
   def setup_rate(%Framerate{} = rate, _), do: rate
-  def setup_rate(rate, opts), do: Framerate.new!(rate, opts)
+
+  def setup_rate(rate, opts) do
+    opts = if is_float(rate), do: Keyword.put_new(opts, :coerce_ntsc?, true), else: opts
+    Framerate.new!(rate, opts)
+  end
 
   # Escapes a timecode function name for use in an ast.
   @spec timecode_func(atom(), Macro.metadata(), [Macro.t()]) :: Macro.t()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [version]
-target = 0.8
+target = 0.9
 release =
 
 [testing]

--- a/test/timecode/timecode_property_test.exs
+++ b/test/timecode/timecode_property_test.exs
@@ -30,7 +30,10 @@ defmodule Vtc.TimecodeTest.Properties.Parse.Helpers do
           false -> nil
         end)
       },
-      fn {rate, ntsc} -> Framerate.new!(rate, ntsc: ntsc) end
+      fn
+        {rate, :non_drop} -> Framerate.new!(rate, ntsc: :non_drop, coerce_ntsc?: true)
+        {rate, nil} -> Framerate.new!(rate, ntsc: nil)
+      end
     )
   end
 
@@ -101,7 +104,7 @@ defmodule Vtc.TimecodeTest.Properties.ParseRoundTripDrop do
     property "timecode | ntsc | drop" do
       check all(
               rate_multiplier <- integer(1..10),
-              rate <- (30 * rate_multiplier) |> Framerate.new!(ntsc: :drop) |> constant(),
+              rate <- (30 * rate_multiplier) |> Framerate.new!(ntsc: :drop, coerce_ntsc?: true) |> constant(),
               timecode_values <- timecode_gen(rate),
               max_runs: 100
             ) do
@@ -205,16 +208,16 @@ defmodule Vtc.TimecodeTest.Properties.Rebase do
     check all(
             frames <- integer(),
             original_rate_x <- integer(1..240),
-            original_ntsc <- boolean(),
+            original_ntsc? <- boolean(),
             target_rate_x <- integer(1..240),
-            target_ntsc <- boolean(),
+            target_ntsc? <- boolean(),
             max_runs: 20
           ) do
-      original_ntsc = if original_ntsc, do: :non_drop, else: nil
-      origina_rate = Framerate.new!(original_rate_x, ntsc: original_ntsc)
+      original_ntsc = if original_ntsc?, do: :non_drop, else: nil
+      origina_rate = Framerate.new!(original_rate_x, ntsc: original_ntsc, coerce_ntsc?: original_ntsc?)
 
-      target_ntsc = if target_ntsc, do: :non_drop, else: nil
-      target_rate = Framerate.new!(target_rate_x, ntsc: target_ntsc)
+      target_ntsc = if target_ntsc?, do: :non_drop, else: nil
+      target_rate = Framerate.new!(target_rate_x, ntsc: target_ntsc, coerce_ntsc?: target_ntsc?)
 
       original = Timecode.with_frames!(frames, origina_rate)
 
@@ -394,11 +397,11 @@ defmodule Vtc.TimecodeTest.Properties.Compare do
     check all(
             [a_frames, b_frames] <- list_of(integer(), length: 2),
             rate_x <- integer(1..240),
-            ntsc <- boolean(),
+            ntsc? <- boolean(),
             max_runs: 100
           ) do
-      ntsc = if ntsc, do: :non_drop, else: nil
-      rate = Framerate.new!(rate_x, ntsc: ntsc)
+      ntsc = if ntsc?, do: :non_drop, else: nil
+      rate = Framerate.new!(rate_x, ntsc: ntsc, coerce_ntsc?: ntsc?)
 
       a = Timecode.with_frames!(a_frames, rate)
       b = Timecode.with_frames!(b_frames, rate)


### PR DESCRIPTION
Changes default behavior to not automatically coerce NTSC values and makes that behavior an option instead.