### PR TITLE
[Bug] Fix NTSC check when simplifies to non-1001 denom

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ iex> [data_02, data_01] |> Enum.sort_by(& &1.tc, Timecode) |> inspect()
 "[%{id: 2, tc: <01:00:00:00 <23.98 NTSC>>}, %{id: 1, tc: <02:00:00:00 <23.98 NTSC>>}]"
 ```
 
-All sensible [arithmatic](https://hexdocs.pm/vtc/Vtc.Timecode.html#arithmatic) 
+All sensible [arithmetic](https://hexdocs.pm/vtc/Vtc.Timecode.html#arithmetic) 
 operations are provided, such as addition, subtraction, and multiplication:
 
 ```elixir

--- a/lib/framerate.ex
+++ b/lib/framerate.ex
@@ -209,12 +209,20 @@ defmodule Vtc.Framerate do
   # coerces a rate to the closest proper NTSC playback rate if the option is set.
   @spec coerce_ntsc_rate(Ratio.t(), ntsc(), coerce? :: boolean()) :: {:ok, Ratio.t()} | {:error, ParseError.t()}
   defp coerce_ntsc_rate(rate, nil, false), do: {:ok, rate}
-  defp coerce_ntsc_rate(%Ratio{denominator: 1001} = rate, _, _), do: {:ok, rate}
-  defp coerce_ntsc_rate(_, _, false), do: {:error, %ParseError{reason: :invalid_ntsc_rate}}
 
   defp coerce_ntsc_rate(rate, _, true) do
     rate = rate |> Rational.round() |> Ratio.new() |> Ratio.mult(Ratio.new(1000, 1001))
     {:ok, rate}
+  end
+
+  defp coerce_ntsc_rate(rate, _, false) do
+    whole_frame = Rational.round(rate)
+
+    if Ratio.new(whole_frame * 1000, 1001) == rate do
+      {:ok, rate}
+    else
+      {:error, %ParseError{reason: :invalid_ntsc_rate}}
+    end
   end
 end
 

--- a/lib/framerate_parse_error.ex
+++ b/lib/framerate_parse_error.ex
@@ -39,7 +39,10 @@ defmodule Vtc.Framerate.ParseError do
   @spec message(t()) :: String.t()
   def message(%{reason: :bad_drop_rate}), do: "drop-frame rates must be divisible by 30000/1001"
   def message(%{reason: :invalid_ntsc}), do: "ntsc is not a valid atom. must be :non_drop, :drop, or nil"
-  def message(%{reason: :invalid_ntsc_rate}), do: "NTSC rates must be divisible by 1001 when :coerce_ntsc? is false"
+
+  def message(%{reason: :invalid_ntsc_rate}),
+    do: "NTSC rates must be equivalent to `(timebase * 1000)/1001` when :coerce_ntsc? is false"
+
   def message(%{reason: :unrecognized_format}), do: "framerate string format not recognized"
   def message(%{reason: :imprecise}), do: "non-whole floats are not precise enough to create a non-NTSC Framerate"
 end

--- a/lib/timcode.ex
+++ b/lib/timcode.ex
@@ -41,7 +41,7 @@ defmodule Vtc.Timecode do
   "[%{id: 2, tc: <01:00:00:00 <23.98 NTSC>>}, %{id: 1, tc: <02:00:00:00 <23.98 NTSC>>}]"
   ```
 
-  ## Arithmatic Autocasting
+  ## Arithmetic Autocasting
 
   For operators that take two `timecode values`, likt `add/3` or `compare/2`, as long as
   one argument is a [Timecode](`Vtc.Timecode`) value, `a` or `b` May be any value that
@@ -446,7 +446,7 @@ defmodule Vtc.Timecode do
   @spec gte?(a :: t() | Frames.t(), b :: t() | Frames.t()) :: boolean()
   def gte?(a, b), do: compare(a, b) in [:gt, :eq]
 
-  @doc section: :arithmatic
+  @doc section: :arithmetic
   @doc """
   Add two timecodes.
 
@@ -501,7 +501,7 @@ defmodule Vtc.Timecode do
     a.seconds |> Ratio.add(b.seconds) |> with_seconds!(a.rate, opts)
   end
 
-  @doc section: :arithmatic
+  @doc section: :arithmetic
   @doc """
   Subtract `b` from `a`.
 
@@ -575,7 +575,7 @@ defmodule Vtc.Timecode do
   defp cast_op_args(%__MODULE__{} = a, b), do: {a, with_frames!(b, a.rate)}
   defp cast_op_args(a, %__MODULE__{} = b), do: {with_frames!(a, b.rate), b}
 
-  @doc section: :arithmatic
+  @doc section: :arithmetic
   @doc """
   Scales `a` by `b`.
 
@@ -606,7 +606,7 @@ defmodule Vtc.Timecode do
   @spec mult(a :: t(), b :: Ratio.t() | number(), opts :: [round: maybe_round()]) :: t()
   def mult(a, b, opts \\ []), do: a.seconds |> Ratio.mult(Ratio.new(b)) |> with_seconds!(a.rate, opts)
 
-  @doc section: :arithmatic
+  @doc section: :arithmetic
   @doc """
   Divides `dividend` by `divisor`.
 
@@ -645,7 +645,7 @@ defmodule Vtc.Timecode do
     dividend.seconds |> Ratio.div(Ratio.new(divisor)) |> with_seconds!(dividend.rate, opts)
   end
 
-  @doc section: :arithmatic
+  @doc section: :arithmetic
   @doc """
   Divides the total frame count of `dividend` by `divisor` and returns both a quotient
   and a remainder.
@@ -696,7 +696,7 @@ defmodule Vtc.Timecode do
     end
   end
 
-  @doc section: :arithmatic
+  @doc section: :arithmetic
   @doc """
   Devides the total frame count of `dividend` by `devisor`, and returns the remainder.
 
@@ -727,7 +727,7 @@ defmodule Vtc.Timecode do
         ) :: t()
   def rem(dividend, divisor, opts \\ []), do: dividend |> divrem(Ratio.new(divisor), opts) |> elem(1)
 
-  @doc section: :arithmatic
+  @doc section: :arithmetic
   @doc """
   As the kernel `-/1` function.
 
@@ -755,7 +755,7 @@ defmodule Vtc.Timecode do
   @spec minus(t()) :: t()
   def minus(tc), do: %{tc | seconds: Ratio.minus(tc.seconds)}
 
-  @doc section: :arithmatic
+  @doc section: :arithmetic
   @doc """
   Returns the absolute value of `tc`.
 
@@ -780,7 +780,7 @@ defmodule Vtc.Timecode do
   @spec abs(t()) :: t()
   def abs(tc), do: %{tc | seconds: Ratio.abs(tc.seconds)}
 
-  @doc section: :arithmatic
+  @doc section: :arithmetic
   @doc """
   Evalutes timecode mathematical expressions in a `do` block.
 
@@ -834,7 +834,7 @@ defmodule Vtc.Timecode do
   ```
 
   Just like the regular [Timecode](`Vtc.Timecode`) functions, only one value in an
-  arithmatic expression needs to be a [Timecode](`Vtc.Timecode`) value. In the case
+  arithmetic expression needs to be a [Timecode](`Vtc.Timecode`) value. In the case
   above, since multiplication happens first, that's `b`:
 
   ```elixir

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Vtc.MixProject do
           Manipulate: &(&1[:section] == :manipulate),
           Inspect: &(&1[:section] == :inspect),
           Compare: &(&1[:section] == :compare),
-          Arithmatic: &(&1[:section] == :arithmatic),
+          Arithmetic: &(&1[:section] == :arithmetic),
           Convert: &(&1[:section] == :convert),
           Consts: &(&1[:section] == :consts),
           Perfs: &(&1[:section] == :perfs)

--- a/test/framerate_test.exs
+++ b/test/framerate_test.exs
@@ -212,6 +212,16 @@ defmodule Vtc.FramerateTest do
       assert test_case.timebase == Framerate.timebase(parsed)
       assert test_case.ntsc == parsed.ntsc
     end
+
+    property "parse NTSC, non-drop rates" do
+      check all(timebase <- StreamData.positive_integer()) do
+        playback = Ratio.new(timebase * 1000, 1001)
+
+        assert {:ok, framerate} = Framerate.new(playback, ntsc: :non_drop)
+        assert framerate.playback == playback
+        assert framerate.ntsc == :non_drop
+      end
+    end
   end
 
   describe "#consts" do

--- a/test/framerate_test.exs
+++ b/test/framerate_test.exs
@@ -198,10 +198,11 @@ defmodule Vtc.FramerateTest do
       @tag test_case: this_case
       test "coerce_ntsc?: error on #{inspect(this_case.input)}", context do
         %{input: input} = context
+        expected_message = "NTSC rates must be equivalent to `(timebase * 1000)/1001` when :coerce_ntsc? is false"
 
         assert {:error, error} = Framerate.new(input, ntsc: :non_drop)
         assert error.reason == :invalid_ntsc_rate
-        assert ParseError.message(error) == "NTSC rates must be divisible by 1001 when :coerce_ntsc? is false"
+        assert ParseError.message(error) == expected_message
       end
     end
 

--- a/test/framerate_test.exs
+++ b/test/framerate_test.exs
@@ -2,6 +2,7 @@ defmodule Vtc.FramerateTest do
   @moduledoc false
 
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   import Vtc.TestSetups
 
@@ -71,6 +72,17 @@ defmodule Vtc.FramerateTest do
         coerce_ntsc?: true,
         playback: Ratio.new(60_000, 1001),
         timebase: Ratio.new(60, 1)
+      },
+      %{
+        name: "11000/1001 NTSC",
+        inputs: [
+          Ratio.new(11_000, 1001),
+          "11000/1001"
+        ],
+        ntsc: :non_drop,
+        coerce_ntsc?: false,
+        playback: Ratio.new(11_000, 1001),
+        timebase: Ratio.new(11, 1)
       },
       %{
         name: "24 fps",

--- a/test/timecode/timecode_property_test.exs
+++ b/test/timecode/timecode_property_test.exs
@@ -228,7 +228,7 @@ defmodule Vtc.TimecodeTest.Properties.Rebase do
   end
 end
 
-defmodule Vtc.TimecodeTest.Properties.Arithmatic do
+defmodule Vtc.TimecodeTest.Properties.Arithmetic do
   @moduledoc false
 
   use ExUnit.Case, async: true

--- a/zdocs/quickstart.cheatmd
+++ b/zdocs/quickstart.cheatmd
@@ -187,7 +187,7 @@ iex> Timecode.with_frames(feet_and_frames, Rates.f23_98())
 "{:ok, <01:15:00:00 <23.98 NTSC>>}"
 ```
 
-## Arithmatic
+## Arithmetic
 {: .col-2}
 
 ### .
@@ -356,7 +356,7 @@ iex> Timecode.lt?(a, b)
 true
 ```
 
-Like arithmatic, we can compare directly with a timecode string:
+Like arithmetic, we can compare directly with a timecode string:
 
 #### [compare/2](`Vtc.Timecode.compare/2`) with string
 


### PR DESCRIPTION
Some non-standard NTSC framerates can simply to have a non-1001 denominator. For instance: `10.98` is defined as `11000/1001`, which simplifies to `1000/91`.

This PR: 

- Fixes a bad parsing error under those circumstances.
- Misspelling of 'arithmetic' fixed in docs.