### PR TITLE
[Feaeture] Add "private" PgRational plpgsql `simplify(rational)` function

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,8 @@
 import Config
 
 config :vtc,
-  env: config_env(),
-  include_postgres_types?: true
+  env: config_env()
+
+config :vtc, Postgres, include?: true
 
 import_config "#{config_env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,14 @@ config :vtc, Vtc.Test.Support.Repo,
   password: "postgres",
   hostname: "localhost",
   database: "vtc_test",
-  log: false
+  log: false,
+  vtc: [
+    pg_rational: [
+      functions_schema: :rational,
+      functions_private_schema: :rational_private,
+      functions_prefix: ""
+    ]
+  ]
 
 config :vtc,
   ecto_repos: [Vtc.Test.Support.Repo]

--- a/lib/ecto/postgres/pg_rational.ex
+++ b/lib/ecto/postgres/pg_rational.ex
@@ -9,7 +9,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational do
   The composite type is defined as follows:
 
   ```sql
-  CREATE TYPE public.rational as (
+  CREATE TYPE rational as (
     numerator bigint,
     denominator bigint
   )
@@ -20,6 +20,9 @@ defpgmodule Vtc.Ecto.Postgres.PgRational do
   ```sql
   SELECT (1, 2)::rational
   ```
+
+  See `Vtc.Ecto.Postgres.PgRational.Migrations` for more information on how to create
+  `rational` and it's supporting functions in your database.
 
   ## Field migrations
 
@@ -78,7 +81,6 @@ defpgmodule Vtc.Ecto.Postgres.PgRational do
 
   - Strings formatted as `'numerator/denominator'`. Useful for casting from a JSON
     string.
-
   """
 
   use Ecto.Type

--- a/lib/ecto/postgres/pg_rational_migrations.ex
+++ b/lib/ecto/postgres/pg_rational_migrations.ex
@@ -117,7 +117,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     :ok =
       Migration.execute("""
         DO $$ BEGIN
-          CREATE SCHEMA rationals;
+          CREATE SCHEMA rational;
           EXCEPTION WHEN duplicate_schema
             THEN null;
         END $$;

--- a/mix.exs
+++ b/mix.exs
@@ -67,15 +67,15 @@ defmodule Vtc.MixProject do
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
-    include_postgres_types? = not Application.get_env(:vtc, :include_postgres_types?, false)
+    include_postgrex? = not (:vtc |> Application.get_env(Postgres, []) |> Keyword.get(:include?, false))
 
     [
       # Library Dependencies
       {:decimal, "~> 2.0"},
       {:ratio, "~> 3.0"},
-      {:ecto, "~> 3.10", optional: include_postgres_types?},
-      {:ecto_sql, "~> 3.10", optional: include_postgres_types?},
-      {:postgrex, ">= 0.0.0", optional: include_postgres_types?},
+      {:ecto, "~> 3.10", optional: include_postgrex?},
+      {:ecto_sql, "~> 3.10", optional: include_postgrex?},
+      {:postgrex, ">= 0.0.0", optional: include_postgrex?},
 
       # Test dependencies
       {:covertool, "~> 2.0", only: [:test]},

--- a/test/ecto/postgres/pg_rational_test.exs
+++ b/test/ecto/postgres/pg_rational_test.exs
@@ -111,7 +111,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
       assert :error = PgRational.load([3, 4])
     end
 
-    test "fails on SQL expression" do
+    test "fails on SQL string" do
       assert :error = PgRational.load("(3, 4)")
     end
 
@@ -257,6 +257,86 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
                  """)
 
         assert %Postgrex.Error{postgres: %{code: :check_violation, constraint: "b_denominator_positive"}} = error
+      end
+    end
+  end
+
+  describe "#Postgres rational_private.greatest_common_denominator/2" do
+    gcd_table = [
+      %{a: 2, b: 4, expected: 2},
+      %{a: 21, b: 14, expected: 7},
+      %{a: 23, b: 14, expected: 1},
+      %{a: 1000, b: 70, expected: 10}
+    ]
+
+    table_test "<%= a %>, <%= b %> == <%= expected %>", gcd_table, test_case do
+      %{a: a, b: b, expected: expected} = test_case
+
+      assert %Postgrex.Result{rows: rows} = Repo.query!("SELECT rational_private.greatest_common_denominator(#{a}, #{b})")
+
+      assert [[^expected]] = rows
+    end
+
+    table_test "-<%= a %>, <%= b %> == <%= expected %>", gcd_table, test_case do
+      %{a: a, b: b, expected: expected} = test_case
+
+      assert %Postgrex.Result{rows: rows} =
+               Repo.query!("SELECT rational_private.greatest_common_denominator(-#{a}, #{b})")
+
+      assert [[^expected]] = rows
+    end
+
+    table_test "<%= a %>, -<%= b %> == <%= expected %>", gcd_table, test_case do
+      %{a: a, b: b, expected: expected} = test_case
+
+      assert %Postgrex.Result{rows: rows} =
+               Repo.query!("SELECT rational_private.greatest_common_denominator(#{a}, -#{b})")
+
+      assert [[^expected]] = rows
+    end
+
+    table_test "-<%= a %>, -<%= b %> == <%= expected %>", gcd_table, test_case do
+      %{a: a, b: b, expected: expected} = test_case
+
+      assert %Postgrex.Result{rows: rows} =
+               Repo.query!("SELECT rational_private.greatest_common_denominator(-#{a}, -#{b})")
+
+      assert [[^expected]] = rows
+    end
+  end
+
+  describe "#Postgres rational_private.simplify/1" do
+    simplify_table = [
+      %{numerator: 2, denominator: 4, expected: Ratio.new(1, 2)},
+      %{numerator: -2, denominator: 4, expected: Ratio.new(-1, 2)},
+      %{numerator: 2, denominator: -4, expected: Ratio.new(-1, 2)},
+      %{numerator: -2, denominator: -4, expected: Ratio.new(1, 2)},
+      %{numerator: 10, denominator: 100, expected: Ratio.new(1, 10)},
+      %{numerator: 3, denominator: 39, expected: Ratio.new(1, 13)},
+      %{numerator: 4, denominator: 9, expected: Ratio.new(4, 9)}
+    ]
+
+    table_test "<%= numerator %>/<%= denominator %> == <%= expected %>", simplify_table, test_case do
+      %{numerator: numerator, denominator: denominator, expected: expected} = test_case
+
+      assert %Postgrex.Result{rows: [[db_record]]} =
+               Repo.query!("SELECT rational_private.simplify((#{numerator}, #{denominator})::rational)")
+
+      assert db_record == {expected.numerator, expected.denominator}
+    end
+
+    property "mirrors Ratio.new" do
+      check all(
+              numerator <- StreamData.integer(),
+              denominator <- StreamData.filter(StreamData.integer(), &(&1 != 0))
+            ) do
+        expected = Ratio.new(numerator, denominator)
+
+        assert %Postgrex.Result{rows: [[{db_numerator, db_denominator}]]} =
+                 Repo.query!("SELECT rational_private.simplify((#{numerator}, #{denominator})::rational)")
+
+        assert db_numerator == expected.numerator
+        assert db_denominator == expected.denominator
       end
     end
   end

--- a/zdocs/quickstart.cheatmd
+++ b/zdocs/quickstart.cheatmd
@@ -457,3 +457,5 @@ config :vtc,
   env: config_env(),
   include_postgres_types?: true
 ```
+
+See each posgres type for information on it's configuration.


### PR DESCRIPTION
- Adds the ability to make function schemas configurable:
- Adds two private functions:
    - `greatest_common_denominator`
    - `simplify`

These functions will be needed to simplify fractions at the end of every other fraction operation, to avoid overflows from numerator/denominator pairs growing bigger and bigger with each operation.

NOTE:

`Postgres.Utils.create_plpgsql_function/2` has been made a public function rather than a private helper as several concurrent work streams in separate modules will need this helper in the next few PRs, and would create merge conflicts if they were to each make it public for themselves.