### PR TITLE
[Feature] Add `PgFramerate` Postgres type

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -13,6 +13,11 @@ config :vtc, Vtc.Test.Support.Repo,
       functions_schema: :rational,
       functions_private_schema: :rational_private,
       functions_prefix: ""
+    ],
+    pg_framerate: [
+      functions_schema: :framerate,
+      functions_private_schema: :framerate_private,
+      functions_prefix: ""
     ]
   ]
 

--- a/lib/ecto/postgres/pg_framerate.ex
+++ b/lib/ecto/postgres/pg_framerate.ex
@@ -1,0 +1,227 @@
+use Vtc.Ecto.Postgres.Utils
+
+defpgmodule Vtc.Ecto.Postgres.PgFramerate do
+  @moduledoc """
+  Defines a composite type for storing rational values as a
+  [PgRational](`Vtc.Ecto.Postgres.PgRational`) + list of tags These values are cast to
+  [Framerate](`Vtc.Framerate`) structs for use in application code.
+
+  The composite types iare defined as follows:
+
+  ```sql
+  CREATE TYPE framerate_tags AS ENUM (
+    "drop",
+    "non_drop"
+  )
+  ```
+
+  ```sql
+  CREATE TYPE framerate as (
+    playback rational,
+    tags framerate_tags[]
+  )
+  ```
+
+  `framerate_tags` is designed as such to guarantee forwards-compatibility with future
+  support for features like interlaced timecode.
+
+  Framerate values can be cast in SQL expressions like so:
+
+  ```sql
+  SELECT ((24000, 1001), '{non_drop}')::framerate
+  ```
+
+  ## Framerate tags
+
+  The following values are valid tags:
+
+  - `drop`: Indicates NTSC, drop-frame timecode
+  - `non_drop`: Indicated NTSC, non-drop timecode
+
+  ## Field migrations
+
+  You can create `framerate` fields during a migration like so:
+
+  ```elixir
+  create table("rationals") do
+    add(:a, PgFramerate.type())
+    add(:b, PgFramerate.type())
+  end
+  ```
+
+  ## Schema fields
+
+  Then in your schema module:
+
+  ```elixir
+  defmodule MyApp.Framerates do
+  @moduledoc false
+  use Ecto.Schema
+
+  alias Vtc.Ecto.Postgres.PgFramerate
+  alias Vtc.Framerate
+
+  @type t() :: %__MODULE__{
+          a: Framerate.t(),
+          b: Framerate.t()
+        }
+
+  schema "rationals_01" do
+    field(:a, PgFramerate)
+    field(:b, PgFramerate)
+  end
+  ```
+
+  ... notice that the schema field type is [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`),
+  but the type-spec field uses `Framerate.t()`, the type that our DB fields will be
+  deserialized into.
+
+  ## Changesets
+
+  With the above setup, changesets should just work:
+
+  ```elixir
+  def changeset(schema, attrs) do
+    schema
+    |> Changeset.cast(attrs, [:a, :b])
+    |> Changeset.validate_required([:a, :b])
+  end
+  ```
+
+  Framerate values can be cast from the following values in changesets:
+
+  - [Framerate](`Vtc.Framerate`) structs.
+
+  - Maps with the following format:
+
+    ```json
+    {
+      rate: [24000, 1001],
+      ntsc: "non_drop"
+    }
+    ```
+
+    Where `rate` is a value supported by
+    [PgRational](`Vtc.Ecto.Postgres.PgRational`) casting and `ntsc` can be `null`,
+    `"drop"` or `"non_drop"`.
+  """
+
+  use Ecto.Type
+
+  alias Ecto.Changeset
+  alias Vtc.Ecto.Postgres.PgRational
+  alias Vtc.Framerate
+
+  @doc section: :ecto_migrations
+  @doc """
+  The database type for [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`).
+
+  Can be used in migrations as the fields type.
+  """
+  @impl Ecto.Type
+  def type, do: :framerate
+
+  @typedoc """
+  Type of the raw composite value that will be sent to / received from the database.
+  """
+  @type db_record() :: {PgRational.db_record(), [String.t()]}
+
+  # Handles casting PgRational fields in `Ecto.Changeset`s.
+  @doc false
+  @impl Ecto.Type
+  @spec cast(Framerate.t() | %{String.t() => any()} | %{atom() => any()}) :: {:ok, Framerate.t()} | :error
+  def cast(%Framerate{} = framerate), do: {:ok, framerate}
+
+  def cast(json) when is_map(json) do
+    schema = %{
+      playback: PgRational,
+      ntsc: {:parameterized, Ecto.Enum, Ecto.Enum.init(values: [:drop, :non_drop])}
+    }
+
+    changeset =
+      {%{}, schema}
+      |> Changeset.cast(json, [:playback, :ntsc])
+      |> Changeset.validate_required([:playback])
+
+    with {:ok, loaded} <- Changeset.apply_action(changeset, :loaded),
+         {:ok, _} = result <- Framerate.new(loaded.playback, ntsc: Map.get(loaded, :ntsc, nil)) do
+      result
+    else
+      _ -> :error
+    end
+  end
+
+  def cast(_), do: :error
+
+  # Handles converting database records into Ratio structs to be used by the
+  # application.
+  @doc false
+  @impl Ecto.Type
+  @spec load(db_record()) :: {:ok, Framerate.t()} | :error
+  def load({rate, tags}) when is_list(tags) do
+    ntsc = load_ntsc(tags)
+
+    with {:ok, rate_loaded} <- PgRational.load(rate),
+         {:ok, _} = result <- Framerate.new(rate_loaded, ntsc: ntsc) do
+      result
+    else
+      _ -> :error
+    end
+  end
+
+  def load(_), do: :error
+
+  @spec load_ntsc([String.t()]) :: Framerate.ntsc()
+  defp load_ntsc(tags) do
+    cond do
+      "drop" in tags -> :drop
+      "non_drop" in tags -> :non_drop
+      true -> nil
+    end
+  end
+
+  # Handles converting Ratio structs into database records.
+  @doc false
+  @impl Ecto.Type
+  @spec dump(Framerate.t()) :: {:ok, db_record()} | :error
+  def dump(%Framerate{} = framerate) do
+    with {:ok, rational} <- PgRational.dump(framerate.playback) do
+      tags = dump_tags_add_ntsc([], framerate)
+      {:ok, {rational, tags}}
+    end
+  end
+
+  def dump(_), do: :error
+
+  @spec dump_tags_add_ntsc([String.t()], Framerate.t()) :: [String.t()]
+  defp dump_tags_add_ntsc(tags, %{ntsc: :non_drop}), do: ["non_drop" | tags]
+  defp dump_tags_add_ntsc(tags, %{ntsc: :drop}), do: ["drop" | tags]
+  defp dump_tags_add_ntsc(tags, _), do: tags
+
+  @doc section: :ecto_queries
+  @doc """
+  Serialize [Framerate](`Vtc.Framerate`) for use in a query fragment.
+
+  The fragment must explicitly cast the value to a `::framerate` type.
+
+  ## Examples
+
+  ```elixir
+  alias Ecto.Query
+  require Ecto.Query
+
+  alias Vtc.Rates
+  alias Vtc.Ecto.Postgres.PgFramerate
+
+  framerate = Rates.f23_98()
+  framerate_composite = PgFramerate.dump!(framerate)
+
+  Query.from(f in fragment("SELECT ?::framerate as r", ^framerate_composite), select: f.r)
+  ```
+  """
+  @spec dump!(Framerate.t()) :: db_record()
+  def dump!(framerate) do
+    {:ok, db_record} = dump(framerate)
+    db_record
+  end
+end

--- a/lib/ecto/postgres/pg_framerate_migrations.ex
+++ b/lib/ecto/postgres/pg_framerate_migrations.ex
@@ -1,0 +1,156 @@
+use Vtc.Ecto.Postgres.Utils
+
+defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
+  @moduledoc """
+  Migrations for adding framerate types, functions and constraints to a
+  Postgres database.
+  """
+  alias Ecto.Migration
+  alias Ecto.Migration.Constraint
+
+  require Ecto.Migration
+
+  @doc section: :migrations_full
+  @doc """
+  Adds raw SQL queries to a migration for creating the database types, associated
+  functions, casts, operators, and operator families.
+
+  Safe to run multiple times when new functionality is added in updates to this library.
+  Existing values will be skipped.
+
+  ## Types Created
+
+  Calling this macro creates the following type definitions:
+
+  ```sql
+  CREATE TYPE framerate_tags AS ENUM (
+    'drop',
+    'non_drop'
+  );
+  ```
+
+  ```sql
+  CREATE TYPE framerate AS (
+    playback rational,
+    tags framerate_tags[]
+  );
+  ```
+
+  ## Examples
+
+  ```elixir
+  defmodule MyMigration do
+    use Ecto.Migration
+
+    alias Vtc.Ecto.Postgres.PgFramerate
+    require PgFramerate.Migrations
+
+    def change do
+      PgFramerate.Migrations.create_all()
+    end
+  end
+  ```
+  """
+  @spec create_all() :: :ok
+  def create_all do
+    :ok = create_type_framerate_tags()
+    :ok = create_type_framerate()
+
+    :ok
+  end
+
+  @doc section: :migrations_types
+  @spec create_type_framerate_tags() :: :ok
+  @doc """
+  Adds `framerate_tgs` enum type.
+  """
+  def create_type_framerate_tags do
+    :ok =
+      Migration.execute("""
+        DO $$ BEGIN
+          CREATE TYPE framerate_tags AS ENUM (
+            'drop',
+            'non_drop'
+          );
+          EXCEPTION WHEN duplicate_object
+            THEN null;
+        END $$;
+      """)
+  end
+
+  @doc section: :migrations_types
+  @doc """
+  Adds `framerate` composite type.
+  """
+  @spec create_type_framerate() :: :ok
+  def create_type_framerate do
+    :ok =
+      Migration.execute("""
+        DO $$ BEGIN
+          CREATE TYPE framerate AS (
+            playback rational,
+            tags framerate_tags[]
+          );
+          EXCEPTION WHEN duplicate_object
+            THEN null;
+        END $$;
+      """)
+
+    :ok
+  end
+
+  @doc section: :migrations_constraints
+  @doc """
+  Creates basic constraints for a [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`)
+  database field.
+
+  ## Constraints created:
+
+  - `{field_name}_positive`: Checks that the playback speed is positive.
+
+  - `{field_name}_ntsc_tags`: Checks that only `drop` or `non_drop` is set.
+
+  ## Examples
+
+  ```elixir
+  create table("my_table", primary_key: false) do
+    add(:id, :uuid, primary_key: true, null: false)
+    add(:a, PgFramerate.type())
+    add(:b, PgFramerate.type())
+  end
+
+  PgRational.migration_add_field_constraints(:my_table, :a)
+  PgRational.migration_add_field_constraints(:my_table, :b)
+  ```
+  """
+  @spec create_field_constraints(atom(), atom()) :: :ok
+  def create_field_constraints(table, field_name) do
+    positive =
+      Migration.constraint(
+        table,
+        "#{field_name}_positive",
+        check: """
+        (#{field_name}).playback.denominator > 0
+        AND (#{field_name}).playback.numerator > 0
+        """
+      )
+
+    %Constraint{} = Migration.create(positive)
+
+    ntsc_tags =
+      Migration.constraint(
+        table,
+        "#{field_name}_ntsc_tags",
+        check: """
+        NOT (
+          ((#{field_name}).tags) @> '{drop}'::framerate_tags[]
+          AND ((#{field_name}).tags) @> '{non_drop}'::framerate_tags[]
+        )
+        """
+      )
+
+    %Constraint{} = Migration.create(ntsc_tags)
+
+    :ok
+  end
+end

--- a/lib/framerate_parse_error.ex
+++ b/lib/framerate_parse_error.ex
@@ -30,13 +30,20 @@ defmodule Vtc.Framerate.ParseError do
   Type of `ParseError`
   """
   @type t() :: %__MODULE__{
-          reason: :bad_drop_rate | :invalid_ntsc | :invalid_ntsc_rate | :unrecognized_format | :imprecise
+          reason:
+            :non_positive
+            | :bad_drop_rate
+            | :invalid_ntsc
+            | :invalid_ntsc_rate
+            | :unrecognized_format
+            | :imprecise
         }
 
   @doc """
   Returns a message for the error reason.
   """
   @spec message(t()) :: String.t()
+  def message(%{reason: :non_positive}), do: "must be positive"
   def message(%{reason: :bad_drop_rate}), do: "drop-frame rates must be divisible by 30000/1001"
   def message(%{reason: :invalid_ntsc}), do: "ntsc is not a valid atom. must be :non_drop, :drop, or nil"
 

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,12 @@ defmodule Vtc.MixProject do
           "Frames Formats": [Frames.FeetAndFrames, Frames.TimecodeStr],
           "Seconds Formats": [Seconds.PremiereTicks, Seconds.RuntimeStr],
           "Source Protocols": [Seconds, Frames],
-          "Ecto Types": [Vtc.Ecto.Postgres.PgRational, Vtc.Ecto.Postgres.PgRational.Migrations],
+          "Ecto Types": [
+            Vtc.Ecto.Postgres.PgRational,
+            Vtc.Ecto.Postgres.PgRational.Migrations,
+            Vtc.Ecto.Postgres.PgFramerate,
+            Vtc.Ecto.Postgres.PgFramerate.Migrations
+          ],
           "Test Utilities": [Vtc.TestUtls.StreamDataVtc]
         ],
         groups_for_docs: [

--- a/priv/repo/migrations/20230615183016_add_rational_type.exs
+++ b/priv/repo/migrations/20230615183016_add_rational_type.exs
@@ -4,8 +4,6 @@ defmodule Vtc.Test.Support.Repo.Migrations.AddRationalType do
 
   alias Vtc.Ecto.Postgres.PgRational
 
-  require PgRational.Migrations
-
   def change do
     :ok = PgRational.Migrations.create_all()
     :ok = PgRational.Migrations.create_all()

--- a/priv/repo/migrations/20230615185108_add_rational_schemas.exs
+++ b/priv/repo/migrations/20230615185108_add_rational_schemas.exs
@@ -4,8 +4,6 @@ defmodule Vtc.Test.Support.Repo.Migrations.AddRationalSchemas do
 
   alias Vtc.Ecto.Postgres.PgRational
 
-  require PgRational.Migrations
-
   def change do
     create table("rationals_01", primary_key: false) do
       add(:id, :uuid, primary_key: true, null: false)

--- a/priv/repo/migrations/20230621221423_add_framerate_type.exs
+++ b/priv/repo/migrations/20230621221423_add_framerate_type.exs
@@ -1,0 +1,11 @@
+defmodule Vtc.Test.Support.Repo.Migrations.AddFramerateType do
+  @moduledoc false
+  use Ecto.Migration
+
+  alias Vtc.Ecto.Postgres.PgFramerate
+
+  def change do
+    :ok = PgFramerate.Migrations.create_all()
+    :ok = PgFramerate.Migrations.create_all()
+  end
+end

--- a/priv/repo/migrations/20230622002903_add_framerate_schemas.exs
+++ b/priv/repo/migrations/20230622002903_add_framerate_schemas.exs
@@ -1,0 +1,16 @@
+defmodule Vtc.Test.Support.Repo.Migrations.AddFramerateSchemas do
+  @moduledoc false
+  use Ecto.Migration
+
+  alias Vtc.Ecto.Postgres.PgFramerate
+
+  def change do
+    create table("framerates_01", primary_key: false) do
+      add(:id, :uuid, primary_key: true, null: false)
+      add(:a, PgFramerate.type())
+      add(:b, PgFramerate.type())
+    end
+
+    :ok = PgFramerate.Migrations.create_field_constraints(:framerates_01, :b)
+  end
+end

--- a/test/ecto/postgres/pg_framerate_test.exs
+++ b/test/ecto/postgres/pg_framerate_test.exs
@@ -1,0 +1,428 @@
+defmodule Vtc.Ecto.Postgres.PgFramerateTest do
+  use Vtc.Test.Support.EctoCase, async: true
+  use ExUnitProperties
+
+  alias Ecto.Changeset
+  alias Ecto.Query
+  alias Vtc.Ecto.Postgres.PgFramerate
+  alias Vtc.Framerate
+  alias Vtc.Rates
+  alias Vtc.Test.Support.FramerateSchema01
+  alias Vtc.TestUtls.StreamDataVtc
+
+  require Query
+
+  describe "#cast/1" do
+    cast_table = [
+      %{
+        name: "%Framerate{} struct",
+        input: Rates.f23_98(),
+        expected: Rates.f23_98()
+      },
+      %{
+        name: "map with playback string",
+        input: %{playback: "24/1"},
+        expected: Rates.f24()
+      },
+      %{
+        name: "map with playback array",
+        input: %{playback: [24, 1]},
+        expected: Rates.f24()
+      },
+      %{
+        name: "map with playback Ratio",
+        input: %{playback: Ratio.new(24, 1)},
+        expected: Rates.f24()
+      },
+      %{
+        name: "map with ntsc: 'drop'",
+        input: %{playback: "30000/1001", ntsc: "drop"},
+        expected: Rates.f29_97_df()
+      },
+      %{
+        name: "map with ntsc: 'non_drop'",
+        input: %{playback: "24000/1001", ntsc: "non_drop"},
+        expected: Rates.f23_98()
+      },
+      %{
+        name: "map with ntsc: :drop",
+        input: %{playback: "30000/1001", ntsc: :drop},
+        expected: Rates.f29_97_df()
+      },
+      %{
+        name: "map with ntsc: :non_drop",
+        input: %{playback: "24000/1001", ntsc: :non_drop},
+        expected: Rates.f23_98()
+      },
+      %{
+        name: "map with ntsc: `nil`",
+        input: %{playback: "24/1", ntsc: nil},
+        expected: Rates.f24()
+      }
+    ]
+
+    table_test "<%= name %>", cast_table, test_case do
+      %{input: input, expected: expected} = test_case
+      assert {:ok, result} = PgFramerate.cast(input)
+      assert result == expected
+    end
+
+    table_test "<%= name %> | string keys", cast_table, test_case,
+      if: is_map(test_case.input) and not is_struct(test_case.input) do
+      %{input: input, expected: expected} = test_case
+      input = input |> Enum.map(fn {key, value} -> {Atom.to_string(key), value} end) |> Map.new()
+
+      assert {:ok, result} = PgFramerate.cast(input)
+      assert result == expected
+    end
+
+    property "succeeds with `:playback` string" do
+      check all(framerate <- StreamDataVtc.framerate()) do
+        input = %{
+          playback: "#{framerate.playback.numerator}/#{framerate.playback.denominator}",
+          ntsc: framerate.ntsc
+        }
+
+        assert {:ok, result} = PgFramerate.cast(input)
+        assert result == framerate
+      end
+    end
+
+    property "succeeds with `:playback` array" do
+      check all(framerate <- StreamDataVtc.framerate()) do
+        input = %{
+          playback: [framerate.playback.numerator, framerate.playback.denominator],
+          ntsc: framerate.ntsc
+        }
+
+        assert {:ok, result} = PgFramerate.cast(input)
+        assert result == framerate
+      end
+    end
+
+    table_test "succeeds in changesets | <%= name %>", cast_table, test_case do
+      %{input: input, expected: expected} = test_case
+
+      attrs = %{a: input, b: input}
+
+      assert {:ok, result} = %FramerateSchema01{} |> FramerateSchema01.changeset(attrs) |> Changeset.apply_action(:test)
+      assert %FramerateSchema01{} = result
+      assert result.a == expected
+      assert result.b == expected
+    end
+
+    table_test "succeeds in changesets | <%= name %> | string keys", cast_table, test_case,
+      if: is_map(test_case.input) and not is_struct(test_case.input) do
+      %{input: input, expected: expected} = test_case
+
+      input = input |> Enum.map(fn {key, value} -> {Atom.to_string(key), value} end) |> Map.new()
+      attrs = %{a: input, b: input}
+
+      assert {:ok, result} = %FramerateSchema01{} |> FramerateSchema01.changeset(attrs) |> Changeset.apply_action(:test)
+      assert %FramerateSchema01{} = result
+      assert result.a == expected
+      assert result.b == expected
+    end
+
+    cast_error_table = [
+      %{
+        name: "bad non_drop rate",
+        input: %{playback: [24_000, 1002], ntsc: :non_drop}
+      },
+      %{
+        name: "bad drop rate",
+        input: %{playback: [24_000, 1001], ntsc: :drop}
+      },
+      %{
+        name: "negative non_drop",
+        input: %{playback: [-24_000, 1001], ntsc: :non_drop}
+      },
+      %{
+        name: "negative drop",
+        input: %{playback: [-30_000, 1001], ntsc: :drop}
+      },
+      %{
+        name: "negative true",
+        input: %{playback: [-24, 1], ntsc: :drop}
+      },
+      %{
+        name: ":playback integer",
+        input: %{playback: 24, ntsc: nil}
+      },
+      %{
+        name: ":playback float",
+        input: %{playback: 24.0, ntsc: nil}
+      }
+    ]
+
+    table_test "errors on <%= name %>", cast_error_table, test_case do
+      %{input: input} = test_case
+
+      assert :error = PgFramerate.cast(input)
+    end
+
+    table_test "errors on <%= name %> in changesets", cast_error_table, test_case do
+      %{input: input} = test_case
+
+      attrs = %{a: input, b: input}
+
+      assert %Changeset{valid?: false, errors: errors} = FramerateSchema01.changeset(%FramerateSchema01{}, attrs)
+      assert {:a, {"is invalid", [type: PgFramerate, validation: :cast]}} in errors
+      assert {:b, {"is invalid", [type: PgFramerate, validation: :cast]}} in errors
+    end
+  end
+
+  serilization_table = [
+    %{
+      application_value: Rates.f23_98(),
+      database_record: {{24_000, 1001}, ["non_drop"]}
+    },
+    %{
+      application_value: Rates.f29_97_df(),
+      database_record: {{30_000, 1001}, ["drop"]}
+    },
+    %{
+      application_value: Rates.f24(),
+      database_record: {{24, 1}, []}
+    },
+    %{
+      application_value: Framerate.new!(Ratio.new(24_000, 1001), ntsc: nil),
+      database_record: {{24_000, 1001}, []}
+    }
+  ]
+
+  describe "#dump/1" do
+    table_test "succeeds on <%= application_value %>", serilization_table, test_case do
+      %{application_value: application_value, database_record: database_record} = test_case
+
+      assert {:ok, result} = PgFramerate.dump(application_value)
+      assert result == database_record
+    end
+
+    property "succeeds on good framerate" do
+      check all(framerate <- StreamDataVtc.framerate()) do
+        assert {:ok, result} = PgFramerate.dump(framerate)
+        chack_dumped(result, framerate)
+      end
+    end
+  end
+
+  describe "#dump!/1" do
+    table_test "<%= application_value %>", serilization_table, test_case do
+      %{application_value: application_value, database_record: database_record} = test_case
+
+      assert PgFramerate.dump!(application_value) == database_record
+    end
+
+    property "succeeds on good framerate" do
+      check all(framerate <- StreamDataVtc.framerate()) do
+        result = PgFramerate.dump!(framerate)
+        chack_dumped(result, framerate)
+      end
+    end
+  end
+
+  @spec chack_dumped(PgFramerate.db_record(), Framerate.t()) :: term()
+  defp chack_dumped(result, input) do
+    assert {{numerator, denominator}, tags} = result
+    assert numerator == input.playback.numerator
+    assert denominator == input.playback.denominator
+    assert is_list(tags)
+
+    case input.ntsc do
+      :drop -> assert "drop" in tags
+      :non_drop -> assert "non_drop" in tags
+      nil -> assert "drop" not in tags and "non_drop" not in tags
+    end
+  end
+
+  describe "#load/1" do
+    table_test "<%= application_value %>", serilization_table, test_case do
+      %{application_value: application_value, database_record: database_record} = test_case
+
+      assert {:ok, result} = PgFramerate.load(database_record)
+      assert result == application_value
+    end
+  end
+
+  property "round trip dump/1 -> load/1" do
+    check all(framerate <- StreamDataVtc.framerate()) do
+      assert {:ok, dumped} = PgFramerate.dump(framerate)
+      assert {:ok, ^framerate} = PgFramerate.load(dumped)
+    end
+  end
+
+  describe "#SELECT" do
+    basic_query_table = [
+      %{
+        raw_sql: "((24, 1), '{}')",
+        expected: {{24, 1}, []}
+      },
+      %{
+        raw_sql: "((24000, 1001), '{non_drop}')",
+        expected: {{24_000, 1001}, ["non_drop"]}
+      },
+      %{
+        raw_sql: "((30000, 1001), '{drop}')",
+        expected: {{30_000, 1001}, ["drop"]}
+      }
+    ]
+
+    table_test "literal | <%= raw_sql %>", basic_query_table, test_case do
+      %{raw_sql: raw_sql, expected: expected} = test_case
+      assert %Postgrex.Result{rows: [[db_record]]} = Repo.query!("SELECT #{raw_sql}::framerate")
+      assert db_record == expected
+    end
+
+    table_test "placeholder | <%= application_value %>", serilization_table, test_case do
+      %{database_record: database_record} = test_case
+
+      query = Query.from(f in fragment("SELECT ?::framerate as r", ^database_record), select: f.r)
+      assert Repo.one!(query) == database_record
+    end
+
+    table_test "playback field | <%= application_value %>", serilization_table, test_case do
+      %{database_record: {expected, _} = database_record} = test_case
+
+      query = Query.from(f in fragment("SELECT (?::framerate).playback as r", ^database_record), select: f.r)
+      assert Repo.one!(query) == expected
+    end
+
+    table_test "tags field | <%= application_value %>", serilization_table, test_case do
+      %{database_record: {_, expected} = database_record} = test_case
+
+      query = Query.from(f in fragment("SELECT (?::framerate).tags as r", ^database_record), select: f.r)
+      assert Repo.one!(query) == expected
+    end
+
+    property "succeeds on good framerate" do
+      check all(framerate <- StreamDataVtc.framerate()) do
+        assert {:ok, dumped} = PgFramerate.dump(framerate)
+
+        query = Query.from(f in fragment("SELECT ?::framerate as r", ^dumped), select: f.r)
+        assert record = Repo.one!(query)
+        assert {:ok, ^framerate} = PgFramerate.load(record)
+      end
+    end
+  end
+
+  describe "#table serialization" do
+    table_test "can insert into field without constraints", serilization_table, test_case do
+      %{application_value: application_value} = test_case
+
+      assert {:ok, inserted} =
+               %FramerateSchema01{}
+               |> FramerateSchema01.changeset(%{a: application_value})
+               |> Repo.insert()
+
+      assert %FramerateSchema01{} = inserted
+      assert inserted.a == application_value
+      assert inserted.b == nil
+
+      assert %FramerateSchema01{} = record = Repo.get(FramerateSchema01, inserted.id)
+      assert record.a == application_value
+      assert record.b == nil
+    end
+
+    table_test "can insert into field with constraints", serilization_table, test_case do
+      %{application_value: application_value} = test_case
+
+      assert {:ok, inserted} =
+               %FramerateSchema01{}
+               |> FramerateSchema01.changeset(%{b: application_value})
+               |> Repo.insert()
+
+      assert %FramerateSchema01{} = inserted
+      assert inserted.a == nil
+      assert inserted.b == application_value
+
+      assert %FramerateSchema01{} = record = Repo.get(FramerateSchema01, inserted.id)
+      assert record.a == nil
+      assert record.b == application_value
+    end
+
+    property "succeeds on good framerate" do
+      check all(framerate <- StreamDataVtc.framerate()) do
+        assert {:ok, inserted} =
+                 %FramerateSchema01{}
+                 |> FramerateSchema01.changeset(%{a: framerate, b: framerate})
+                 |> Repo.insert()
+
+        assert %FramerateSchema01{} = inserted
+        assert inserted.a == framerate
+        assert inserted.b == framerate
+
+        assert %FramerateSchema01{} = record = Repo.get(FramerateSchema01, inserted.id)
+        assert record.a == framerate
+        assert record.b == framerate
+      end
+    end
+
+    bad_insert_table = [
+      %{
+        name: "negative",
+        value: "((-24000, 1001), '{non_drop}')",
+        field: :b,
+        expected_code: :check_violation,
+        expected_constraint: "b_positive"
+      },
+      %{
+        name: "zero",
+        value: "((0, 1001), '{non_drop}')",
+        field: :b,
+        expected_code: :check_violation,
+        expected_constraint: "b_positive"
+      },
+      %{
+        name: "zero denominator",
+        value: "((24000, 0), '{non_drop}')",
+        field: :b,
+        expected_code: :check_violation,
+        expected_constraint: "b_positive"
+      },
+      %{
+        name: "negative denominator",
+        value: "((24000, -1001), '{non_drop}')",
+        field: :b,
+        expected_code: :check_violation,
+        expected_constraint: "b_positive"
+      },
+      %{
+        name: "bad tag with and without constraints",
+        value: "((24000, 1001), '{bad_tag}')",
+        field: :b,
+        expected_code: :invalid_text_representation
+      },
+      %{
+        name: "multiple ntsc tags",
+        value: "((24000, 1001), '{drop, non_drop}')",
+        field: :b,
+        expected_code: :check_violation,
+        expected_constraint: "b_ntsc_tags"
+      },
+      %{
+        name: "bad tag with and without constraints",
+        value: "((24000, 1001), '{bad_tag}')",
+        field: :a,
+        expected_code: :invalid_text_representation
+      }
+    ]
+
+    table_test "error <%= name %>", bad_insert_table, test_case do
+      %{value: value, expected_code: expected_code, field: field} = test_case
+
+      value_str = "#{value}::framerate"
+      {a, b} = if field == :a, do: {value_str, "NULL"}, else: {"NULL", value_str}
+
+      id = Ecto.UUID.generate()
+      query = "INSERT INTO framerates_01 (id, a, b) VALUES ('#{id}', #{a}, #{b})"
+
+      assert {:error, error} = Repo.query(query)
+      assert %Postgrex.Error{postgres: %{code: ^expected_code} = postgres} = error
+
+      if expected_code == :check_violation do
+        assert postgres.constraint == test_case.expected_constraint
+      end
+    end
+  end
+end

--- a/test/ecto/postgres/pg_rational_test.exs
+++ b/test/ecto/postgres/pg_rational_test.exs
@@ -10,7 +10,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
 
   require Ecto.Query
 
-  describe "cast/1" do
+  describe "#cast/1" do
     test "succeeds with %Ratio{} struct" do
       assert PgRational.cast(Ratio.new(3, 4)) == {:ok, Ratio.new(3, 4)}
     end
@@ -71,7 +71,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     end
   end
 
-  describe "dump/1" do
+  describe "#dump/1" do
     test "succeeds on %Ratio{}" do
       assert {:ok, {3, 4}} = PgRational.dump(Ratio.new(3, 4))
     end
@@ -97,7 +97,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     end
   end
 
-  describe "load/1" do
+  describe "#load/1" do
     test "succeeds on {integer, integer} tuple" do
       assert {:ok, result} = PgRational.load({3, 4})
       assert result == Ratio.new(3, 4)

--- a/test/framerate_test.exs
+++ b/test/framerate_test.exs
@@ -94,6 +94,56 @@ defmodule Vtc.FramerateTest do
         timebase: Ratio.new(24, 1)
       },
       %{
+        name: "error - non-positive | true",
+        inputs: [
+          Ratio.new(0, 1),
+          Ratio.new(-24, 1),
+          0,
+          -24,
+          "0/1",
+          "-24/1",
+          0.0
+        ],
+        ntsc: :non_drop,
+        coerce_ntsc?: true,
+        err: %Framerate.ParseError{reason: :non_positive},
+        err_msg: "must be positive"
+      },
+      %{
+        name: "error - non-positive | :non_drop",
+        inputs: [
+          Ratio.new(0, 1001),
+          Ratio.new(-24_000, 1001),
+          0,
+          -24,
+          "0/1001",
+          "-24000/1001",
+          0.0,
+          -23.98
+        ],
+        ntsc: :non_drop,
+        coerce_ntsc?: true,
+        err: %Framerate.ParseError{reason: :non_positive},
+        err_msg: "must be positive"
+      },
+      %{
+        name: "error - non-positive | :drop",
+        inputs: [
+          Ratio.new(0, 1001),
+          Ratio.new(-30_000, 1001),
+          0,
+          -39,
+          "0/1001",
+          "-30000/1001",
+          0.0,
+          -29.97
+        ],
+        ntsc: :drop,
+        coerce_ntsc?: true,
+        err: %Framerate.ParseError{reason: :non_positive},
+        err_msg: "must be positive"
+      },
+      %{
         name: "error - bad drop",
         inputs: [
           Ratio.new(24, 1),
@@ -141,10 +191,8 @@ defmodule Vtc.FramerateTest do
 
     new_table =
       Enum.flat_map(parse_table, fn test_case ->
-        for {input, index} <- Enum.with_index(test_case.inputs) do
-          test_case
-          |> Map.put(:input, input)
-          |> Map.put(:name, "#{test_case.name} - #{index}: #{inspect(input)} - new")
+        for input <- test_case.inputs do
+          Map.put(test_case, :input, input)
         end
       end)
 

--- a/test/support/framerate_schema_01.ex
+++ b/test/support/framerate_schema_01.ex
@@ -1,0 +1,26 @@
+defmodule Vtc.Test.Support.FramerateSchema01 do
+  @moduledoc """
+  Dummy schema for verifying the Postgres Repo in our test env
+  """
+  use Ecto.Schema
+
+  alias Ecto.Changeset
+  alias Vtc.Ecto.Postgres.PgFramerate
+  alias Vtc.Framerate
+
+  @type t() :: %__MODULE__{
+          id: Ecto.UUID.t(),
+          a: Framerate.t(),
+          b: Framerate.t()
+        }
+
+  @primary_key {:id, Ecto.UUID, autogenerate: true}
+
+  schema "framerates_01" do
+    field(:a, PgFramerate)
+    field(:b, PgFramerate)
+  end
+
+  @spec changeset(%__MODULE__{}, %{atom() => any()}) :: Changeset.t(%__MODULE__{})
+  def changeset(schema, attrs), do: Changeset.cast(schema, attrs, [:a, :b])
+end


### PR DESCRIPTION
Adds a Postgres composite type for framerates

KICKED UNTIL #49 is merged:

 - Add more default constraints:
     - valid NTSC (needs Rational division and multiplication operators first)
     - valid drop (needs Rational division operator first)