### PR TITLE
[FEATURE] Rational Postgres Arithmatic Operators

### DIFF
--- a/lib/ecto/postgres/pg_rational_migrations.ex
+++ b/lib/ecto/postgres/pg_rational_migrations.ex
@@ -187,7 +187,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_functions
   @doc """
-  Adds `rational_private.greatest_common_denominator(a, b)` function that finds the
+  Creates `rational_private.greatest_common_denominator(a, b)` function that finds the
   greatest common denominator between two bigint values.
   """
   @spec create_func_greatest_common_denominator() :: :ok
@@ -218,7 +218,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_functions
   @doc """
-  Adds `rational_private.simplify(rat)` function that simplifies a rational. Used at
+  Creates `rational_private.simplify(rat)` function that simplifies a rational. Used at
   the end of every rational operation to avoid overflows.
   """
   @spec create_func_simplify() :: :ok
@@ -254,7 +254,8 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_functions
   @doc """
-  Returns the negated version of the rational
+  Creates `rational.minus(rat)` function that flips the sign of the input value --
+  makes a positive value negative and a negative value positive.
   """
   @spec create_func_minus() :: :ok
   def create_func_minus do
@@ -275,7 +276,8 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_functions
   @doc """
-  Returns the rational input, rounded to the nearest :bigint
+  Creates `rational.round(rat)` function that returns the rational input, rounded to
+  the nearest :bigint
   """
   @spec create_func_round() :: :ok
   def create_func_round do
@@ -309,6 +311,9 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   end
 
   @doc section: :migrations_functions
+  @doc """
+  Creates a native CAST from `rational` to `double precision`.
+  """
   @spec create_func_cast_to_double_precison() :: :ok
   def create_func_cast_to_double_precison do
     create_func =
@@ -328,7 +333,8 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_functions
   @doc """
-  Creates the backing function for the '+' operator between two rationals.
+  Creates Creates `rational_private.add(a, b)` backing function for the `+` operator
+  between two rationals.
   """
   @spec create_func_add() :: :ok
   def create_func_add do
@@ -354,7 +360,8 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_functions
   @doc """
-  Creates the backing function for the '-' operator between two rationals.
+  Creates Creates `rational_private.sub(a, b)` backing function for the `-` operator
+  between two rationals.
   """
   @spec create_func_sub() :: :ok
   def create_func_sub do
@@ -380,7 +387,8 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_functions
   @doc """
-  Creates the backing function for the '*' operator between two rationals.
+  Creates Creates `rational_private.mult(a, b)` backing function for the `*` operator
+  between two rationals.
   """
   @spec create_func_mult() :: :ok
   def create_func_mult do
@@ -406,7 +414,8 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_functions
   @doc """
-  Creates the backing function for the '*' operator between two rationals.
+  Creates Creates `rational_private.div(a, b)` backing function for the `/` operator
+  between two rationals.
   """
   @spec create_func_div() :: :ok
   def create_func_div do
@@ -432,7 +441,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_operators
   @doc """
-  Creates a custom :rational, :rational + operator.
+  Creates a custom :rational, :rational `+` operator.
   """
   @spec create_op_add() :: :ok
   def create_op_add do
@@ -451,7 +460,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_operators
   @doc """
-  Creates a custom :rational, :rational + operator.
+  Creates a custom :rational, :rational `-` operator.
   """
   @spec create_op_sub() :: :ok
   def create_op_sub do
@@ -470,7 +479,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_operators
   @doc """
-  Creates a custom :rational, :rational * operator.
+  Creates a custom :rational, :rational `*` operator.
   """
   @spec create_op_mult() :: :ok
   def create_op_mult do
@@ -489,7 +498,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_operators
   @doc """
-  Creates a custom :rational, :rational * operator.
+  Creates a custom :rational, :rational `/` operator.
   """
   @spec create_op_div() :: :ok
   def create_op_div do

--- a/lib/ecto/postgres/pg_rational_migrations.ex
+++ b/lib/ecto/postgres/pg_rational_migrations.ex
@@ -462,7 +462,8 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         :+,
         :rational,
         :rational,
-        :"#{private_function_prefix(Migration.repo())}add"
+        :"#{private_function_prefix(Migration.repo())}add",
+        commutator: :+
       )
 
     :ok = Migration.execute(create_op)
@@ -500,7 +501,8 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         :*,
         :rational,
         :rational,
-        :"#{private_function_prefix(Migration.repo())}mult"
+        :"#{private_function_prefix(Migration.repo())}mult",
+        commutator: :*
       )
 
     :ok = Migration.execute(create_op)

--- a/lib/ecto/postgres/pg_rational_migrations.ex
+++ b/lib/ecto/postgres/pg_rational_migrations.ex
@@ -76,6 +76,18 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   section of these docs for details on native database functions
   created.
 
+  ## Operators Created
+
+  See [PgOperators](Vtc.Ecto.Postgres.PgRational.Migrations.html#pgoperators)
+  section of these docs for details on native database operators
+  created.
+
+  ## Casts Created
+
+  See [PgCasts](Vtc.Ecto.Postgres.PgRational.Migrations.html#pgcasts)
+  section of these docs for details on native database operators
+  created.
+
   ## Examples
 
   ```elixir

--- a/lib/ecto/postgres/pg_utils.ex
+++ b/lib/ecto/postgres/pg_utils.ex
@@ -132,4 +132,36 @@ defmodule Vtc.Ecto.Postgres.Utils do
       END $wrapper$;
     """
   end
+
+  @doc """
+  Builds an SQL query for creating a new native CAST
+  """
+  @spec create_operator(atom(), atom(), atom(), atom()) :: raw_sql()
+  def create_operator(name, left_type, right_type, func_name) do
+    """
+    DO $wrapper$ BEGIN
+      CREATE OPERATOR #{name} (
+        LEFTARG = #{left_type},
+        RIGHTARG = #{right_type},
+        FUNCTION = #{func_name}
+      );
+    EXCEPTION WHEN duplicate_function
+      THEN null;
+    END $wrapper$;
+    """
+  end
+
+  @doc """
+  Builds an SQL query for creating a new native CAST
+  """
+  @spec create_cast(atom(), atom(), atom()) :: raw_sql()
+  def create_cast(left_type, right_type, func_name) do
+    """
+    DO $wrapper$ BEGIN
+      CREATE CAST (#{left_type} AS #{right_type}) WITH FUNCTION #{func_name}(#{left_type});
+    EXCEPTION WHEN duplicate_object
+      THEN null;
+    END $wrapper$;
+    """
+  end
 end

--- a/lib/ecto/postgres/pg_utils.ex
+++ b/lib/ecto/postgres/pg_utils.ex
@@ -134,15 +134,19 @@ defmodule Vtc.Ecto.Postgres.Utils do
   end
 
   @doc """
-  Builds an SQL query for creating a new native CAST
+  Builds an SQL query for creating a new native operator.
   """
-  @spec create_operator(atom(), atom(), atom(), atom()) :: raw_sql()
-  def create_operator(name, left_type, right_type, func_name) do
+  @spec create_operator(atom(), atom(), atom(), atom(), commutator: atom()) :: raw_sql()
+  def create_operator(name, left_type, right_type, func_name, opts \\ []) do
+    commutator = Keyword.get(opts, :commutator)
+    commutator_sql = if is_nil(commutator), do: "", else: "COMMUTATOR = #{commutator},"
+
     """
     DO $wrapper$ BEGIN
       CREATE OPERATOR #{name} (
         LEFTARG = #{left_type},
         RIGHTARG = #{right_type},
+        #{commutator_sql}
         FUNCTION = #{func_name}
       );
     EXCEPTION WHEN duplicate_function

--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,8 @@ defmodule Vtc.MixProject do
           Full: &(&1[:section] == :migrations_full),
           PgConstraints: &(&1[:section] == :migrations_constraints),
           PgTypes: &(&1[:section] == :migrations_types),
+          PgCasts: &(&1[:section] == :migrations_casts),
+          PgOperators: &(&1[:section] == :migrations_operators),
           PgFunctions: &(&1[:section] == :migrations_functions)
         ]
       ],


### PR DESCRIPTION
Adds native Postgres arithmetic operators for PgRational type

Examples:

```elixir
      assert {:ok, %{id: record_id}} =
               %RationalsSchema02{}
               |> RationalsSchema02.changeset(%{a: Ratio.new(3, 4), b: Ratio.new(1, 2)})
               |> Repo.insert()

      assert {:ok, result} =
               RationalsSchema02
               |> Query.select([r], r.a + r.b)
               |> Query.where([r], r.id == ^record_id)
               |> Repo.one!()
               |> PgRational.load()

      assert result == Ratio.new(5, 4)
```