### PR TITLE
[Feature] Add PgRational comparison operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install-dev:
 
 .PHONY: test
 test:
-	-mix test --cover --warnings-as-errors
+	-mix test --exclude index_test --cover --warnings-as-errors
 
 .PHONY: lint
 lint:

--- a/lib/ecto/postgres/pg_rational.ex
+++ b/lib/ecto/postgres/pg_rational.ex
@@ -148,12 +148,13 @@ defpgmodule Vtc.Ecto.Postgres.PgRational do
   rational = Ratio.new(1, 2)
   rational_sql = PgRational.dump!(rational)
 
-  Query.from(f in fragment("SELECT ?::rational as r", ^rational_sql), select: f.r)
+  Query.from(f in fragment("SELECT ? as r", ^rational_sql), select: f.r)
   ```
   """
-  @spec dump!(Ratio.t()) :: db_record()
-  def dump!(rational) do
-    {:ok, db_record} = dump(rational)
-    db_record
+  @spec sql(Macro.t()) :: Macro.t()
+  defmacro sql(rational) do
+    quote do
+      type(^unquote(rational), unquote(__MODULE__))
+    end
   end
 end

--- a/priv/repo/migrations/20230615185108_add_rational_schemas.exs
+++ b/priv/repo/migrations/20230615185108_add_rational_schemas.exs
@@ -19,5 +19,7 @@ defmodule Vtc.Test.Support.Repo.Migrations.AddRationalSchemas do
 
     :ok = PgRational.Migrations.create_field_constraints(:rationals_02, :a)
     :ok = PgRational.Migrations.create_field_constraints(:rationals_02, :b)
+
+    create(index("rationals_02", [:b]))
   end
 end

--- a/test/ecto/postgres/pg_index_test.exs
+++ b/test/ecto/postgres/pg_index_test.exs
@@ -1,0 +1,87 @@
+defmodule Vtc.Ecto.Postgres.PgRationalIndexTest do
+  @moduledoc """
+  Expensive tests that insert tens of thousands of records in order to coerce the
+  query planner into using an index in order to assert that it CAN, and that operator
+  families are working as intended.
+
+  To exclude these tests when running locally, use:
+
+  ```mix
+  mix test --exclude index_test
+  ```
+  """
+
+  use Vtc.Test.Support.EctoCase, async: false
+
+  alias Ecto.Query
+  alias Vtc.Ecto.Postgres.PgRational
+  alias Vtc.Test.Support.RationalsSchema02
+
+  require Ecto.Query
+
+  @moduletag :index_test
+
+  describe "PgRational" do
+    test "BTREE indexing" do
+      assert {:ok, %{id: _}} =
+               %RationalsSchema02{}
+               |> RationalsSchema02.changeset(%{a: Ratio.new(1, 2), b: Ratio.new(1, 4)})
+               |> Repo.insert()
+
+      for denominator <- 1..20_000 do
+        assert {:ok, _} =
+                 %RationalsSchema02{}
+                 |> RationalsSchema02.changeset(%{a: Ratio.new(1, 2), b: Ratio.new(1, denominator)})
+                 |> Repo.insert()
+      end
+
+      value = Ratio.new(1, 10_000)
+      expected_plan_snippet = "Index Scan using rationals_02_b_index on rationals_02 r0"
+
+      lt_plan =
+        RationalsSchema02
+        |> Query.select([r], r.id)
+        |> Query.where([r], r.b < type(^value, PgRational))
+        |> then(&Repo.explain(:all, &1))
+        |> dbg()
+
+      assert lt_plan =~ expected_plan_snippet
+
+      lte_plan =
+        RationalsSchema02
+        |> Query.select([r], r.id)
+        |> Query.where([r], r.b <= type(^value, PgRational))
+        |> then(&Repo.explain(:all, &1))
+        |> dbg()
+
+      assert lte_plan =~ expected_plan_snippet
+
+      eq_plan =
+        RationalsSchema02
+        |> Query.select([r], r.id)
+        |> Query.where([r], r.b == type(^value, PgRational))
+        |> then(&Repo.explain(:all, &1))
+        |> dbg()
+
+      assert eq_plan =~ expected_plan_snippet
+
+      gt_plan =
+        RationalsSchema02
+        |> Query.select([r], r.id)
+        |> Query.where([r], r.b > type(^value, PgRational))
+        |> then(&Repo.explain(:all, &1))
+        |> dbg()
+
+      assert gt_plan =~ expected_plan_snippet
+
+      gte_plan =
+        RationalsSchema02
+        |> Query.select([r], r.id)
+        |> Query.where([r], r.b >= type(^value, PgRational))
+        |> then(&Repo.explain(:all, &1))
+        |> dbg()
+
+      assert gte_plan =~ expected_plan_snippet
+    end
+  end
+end

--- a/test/support/framerate_schema_01.ex
+++ b/test/support/framerate_schema_01.ex
@@ -5,7 +5,6 @@ defmodule Vtc.Test.Support.FramerateSchema01 do
   use Ecto.Schema
 
   alias Ecto.Changeset
-  alias Vtc.Ecto.Postgres.PgFramerate
   alias Vtc.Framerate
 
   @type t() :: %__MODULE__{
@@ -17,8 +16,8 @@ defmodule Vtc.Test.Support.FramerateSchema01 do
   @primary_key {:id, Ecto.UUID, autogenerate: true}
 
   schema "framerates_01" do
-    field(:a, PgFramerate)
-    field(:b, PgFramerate)
+    field(:a, Framerate)
+    field(:b, Framerate)
   end
 
   @spec changeset(%__MODULE__{}, %{atom() => any()}) :: Changeset.t(%__MODULE__{})


### PR DESCRIPTION
- Adds native comparison operators to the PgRational type
- Adds btree operator class to the PgRational type
- Framerate Delegates Ecto.type implentation to PgFramerate for direct use in database.

So you can do something like this:

```elixir
filter = Ratio.new(1, 2)

result =
  RationalsSchema02
  |> Query.select([r], r.id)
  |> Query.where([r] r.b > type(^filter, PgRational))
  |> Repo.all()
```

Since there is a btree operator class, you can make indexes on a rational field like normal:

```elixir
create table("rationals_02", primary_key: false) do
  add(:id, :uuid, primary_key: true, null: false)
  add(:a, PgRational.type())
  add(:b, PgRational.type())
end

:ok = PgRational.Migrations.create_field_constraints(:rationals_02, :a)
:ok = PgRational.Migrations.create_field_constraints(:rationals_02, :b)

create(index("rationals_02", [:b]))
```

And then the query planner will pick up on that for the above query:

```text
"Index Scan using rationals_02_b_index on rationals_02 r0  (cost=0.38..8.39 rows=1 width=16)\n  Index Cond: (b > '(1,2)'::rational)"
```

... all with native operators in both Ecto and postgres!