### PR TITLE
[Feature] Add PgTimecode type

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -18,6 +18,11 @@ config :vtc, Vtc.Test.Support.Repo,
       functions_schema: :framerate,
       functions_private_schema: :framerate_private,
       functions_prefix: ""
+    ],
+    pg_timecode: [
+      functions_schema: :timecode,
+      functions_private_schema: :timecode_private,
+      functions_prefix: ""
     ]
   ]
 

--- a/lib/ecto/postgres/pg_framerate.ex
+++ b/lib/ecto/postgres/pg_framerate.ex
@@ -3,10 +3,10 @@ use Vtc.Ecto.Postgres.Utils
 defpgmodule Vtc.Ecto.Postgres.PgFramerate do
   @moduledoc """
   Defines a composite type for storing rational values as a
-  [PgRational](`Vtc.Ecto.Postgres.PgRational`) + list of tags These values are cast to
+  [PgRational](`Vtc.Ecto.Postgres.PgRational`) + list of tags. These values are cast to
   [Framerate](`Vtc.Framerate`) structs for use in application code.
 
-  The composite types iare defined as follows:
+  The composite types are defined as follows:
 
   ```sql
   CREATE TYPE framerate_tags AS ENUM (
@@ -43,11 +43,16 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate do
   You can create `framerate` fields during a migration like so:
 
   ```elixir
+  alias Vtc.Framerate
+
   create table("rationals") do
-    add(:a, PgFramerate.type())
-    add(:b, PgFramerate.type())
+    add(:a, Framerate.type())
+    add(:b, Framerate.type())
   end
   ```
+
+  [Framerate](`Vtc.Framerate`) re-exports the `Ecto.Type` implementation of this module,
+  and can be used any place this module would be used.
 
   ## Schema fields
 
@@ -58,7 +63,6 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate do
   @moduledoc false
   use Ecto.Schema
 
-  alias Vtc.Ecto.Postgres.PgFramerate
   alias Vtc.Framerate
 
   @type t() :: %__MODULE__{
@@ -71,10 +75,6 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate do
     field(:b, Framerate)
   end
   ```
-
-  ... notice that that both the schema field and type-spec use
-  [PgFramerate](`Vtc.Framerate`). That's because `Framerate` delegates an Ecto type
-  implementation to `PgFramerate`, and can be used in it's stead.
 
   ## Changesets
 
@@ -96,12 +96,12 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate do
 
     ```json
     {
-      rate: [24000, 1001],
-      ntsc: "non_drop"
+      "playback": [24000, 1001],
+      "ntsc": "non_drop"
     }
     ```
 
-    Where `rate` is a value supported by
+    Where `playback` is a value supported by
     [PgRational](`Vtc.Ecto.Postgres.PgRational`) casting and `ntsc` can be `null`,
     `"drop"` or `"non_drop"`.
 

--- a/lib/ecto/postgres/pg_framerate_migrations.ex
+++ b/lib/ecto/postgres/pg_framerate_migrations.ex
@@ -90,8 +90,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   @spec create_all() :: :ok
   def create_all do
     :ok = create_type_framerate_tags()
-    :ok = create_function_schemas()
     :ok = create_type_framerate()
+    :ok = create_function_schemas()
 
     :ok
   end
@@ -138,14 +138,16 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
 
   @doc section: :migrations_types
   @doc """
-  Creates schemas to act as namespaces for rational functions:
+  Creates schemas to act as namespaces for framerate functions:
 
-  - `rational`: for user-facing "public" functions that will have backwards
+  - `framerate`: for user-facing "public" functions that will have backwards
     compatibility guarantees and application code support.
 
-  - `rational_private`: for developer-only "private" functions that support the
-    functions in the "rational" schema. Will NOT havr backwards compatibility guarantees
+  - framerate_private`: for developer-only "private" functions that support the
+    functions in the "rational" schema. Will NOT have backwards compatibility guarantees
     NOR application code support.
+
+  These schemas can be configured in your Repo settings.
   """
   @spec create_function_schemas() :: :ok
   def create_function_schemas do
@@ -236,5 +238,5 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   # Fetches PgRational configuration option from `repo`'s configuration.
   @spec get_config(Ecto.Repo.t(), atom(), Keyword.value()) :: Keyword.value()
   defp get_config(repo, opt, default),
-    do: repo.config() |> Keyword.get(:vtc, []) |> Keyword.get(:pg_rational) |> Keyword.get(opt, default)
+    do: repo.config() |> Keyword.get(:vtc, []) |> Keyword.get(:pg_framerate) |> Keyword.get(opt, default)
 end

--- a/lib/ecto/postgres/pg_rational.ex
+++ b/lib/ecto/postgres/pg_rational.ex
@@ -132,29 +132,4 @@ defpgmodule Vtc.Ecto.Postgres.PgRational do
   @spec dump(Ratio.t()) :: {:ok, db_record()} | :error
   def dump(%Ratio{} = rational), do: {:ok, {rational.numerator, rational.denominator}}
   def dump(_), do: :error
-
-  @doc section: :ecto_queries
-  @doc """
-  Serialize `Ratio` for use in a query fragment.
-
-  The fragment must explicitly cast the value to a `::rational` type.
-
-  ## Examples
-
-  ```elixir
-  alias Ecto.Query
-  require Ecto.Query
-
-  rational = Ratio.new(1, 2)
-  rational_sql = PgRational.dump!(rational)
-
-  Query.from(f in fragment("SELECT ? as r", ^rational_sql), select: f.r)
-  ```
-  """
-  @spec sql(Macro.t()) :: Macro.t()
-  defmacro sql(rational) do
-    quote do
-      type(^unquote(rational), unquote(__MODULE__))
-    end
-  end
 end

--- a/lib/ecto/postgres/pg_timecode.ex
+++ b/lib/ecto/postgres/pg_timecode.ex
@@ -1,0 +1,185 @@
+use Vtc.Ecto.Postgres.Utils
+
+defpgmodule Vtc.Ecto.Postgres.PgTimecode do
+  @moduledoc """
+  Defines a composite type for storing rational values as a
+  [PgRational](`Vtc.Ecto.Postgres.PgRational`) real-world playbck seconds,
+  [PgFramerate](`Vtc.Ecto.Postgres.Framerate`) playback rate pair.
+
+  These values are cast to
+  [Timecode](`Vtc.Timecode`) structs for use in application code.
+
+  The composite types is defined as follows:
+
+  ```sql
+  CREATE TYPE timecode as (
+    seconds rational,
+    rate framerate
+  )
+  ```
+
+  ```sql
+  SELECT ((10, 1), ((24, 1), '{non_drop}'))::timecode
+  ```
+
+  ## Field migrations
+
+  You can create `framerate` fields during a migration like so:
+
+  ```elixir
+  alias Vtc.Timecode
+
+  create table("events") do
+    add(:in, Timecode.type())
+    add(:out, Timecode.type())
+  end
+  ```
+
+  [Timecode](`Vtc.Timecode`) re-exports the `Ecto.Type` implementation of this module,
+  and can be used any place this module would be used.
+
+  ## Schema fields
+
+  Then in your schema module:
+
+  ```elixir
+  defmodule MyApp.Event do
+  @moduledoc false
+  use Ecto.Schema
+
+  alias Vtc.Timecode
+
+  @type t() :: %__MODULE__{
+          in: Timecode.t(),
+          out: Timecode.t()
+        }
+
+  schema "events" do
+    field(:in, Timecode)
+    field(:out, Timecode)
+  end
+  ```
+
+  ## Changesets
+
+  With the above setup, changesets should just work:
+
+  ```elixir
+  def changeset(schema, attrs) do
+    schema
+    |> Changeset.cast(attrs, [:in, :out])
+    |> Changeset.validate_required([:in, :out])
+  end
+  ```
+
+  Framerate values can be cast from the following values in changesets:
+
+  - [Timecode](`Vtc.Timecode`) structs.
+
+  - Maps with the following format:
+
+    ```json
+    {
+      "smpte_timecode": "01:00:00:00",
+      "rate": {
+        "playback": [24000, 1001],
+        "ntsc": "non_drop"
+      }
+    }
+    ```
+
+    Where `smpte_timecode` is properly formatted SMPTE timecode string and `playback`
+    is a map value supported by [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`) changeset
+    casts.
+
+  ## Fragments
+
+  Timecode values must be explicitly cast using
+  [type/2](https://hexdocs.pm/ecto/Ecto.Query.html#module-interpolation-and-casting):
+
+  ```elixir
+  timecode = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
+  query = Query.from(f in fragment("SELECT ? as r", type(^timecode, Timecode)), select: f.r)
+  ```
+  """
+
+  use Ecto.Type
+
+  alias Ecto.Changeset
+  alias Vtc.Ecto.Postgres.PgFramerate
+  alias Vtc.Ecto.Postgres.PgRational
+  alias Vtc.Framerate
+  alias Vtc.Source.Frames.TimecodeStr
+  alias Vtc.Timecode
+
+  @doc section: :ecto_migrations
+  @doc """
+  The database type for [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`).
+
+  Can be used in migrations as the fields type.
+  """
+  @impl Ecto.Type
+  def type, do: :timecode
+
+  @typedoc """
+  Type of the raw composite value that will be sent to / received from the database.
+  """
+  @type db_record() :: {PgRational.db_record(), PgFramerate.db_record()}
+
+  # Handles casting PgRational fields in `Ecto.Changeset`s.
+  @doc false
+  @impl Ecto.Type
+  @spec cast(Timecode.t() | %{String.t() => any()} | %{atom() => any()}) :: {:ok, Framerate.t()} | :error
+  def cast(%Timecode{} = timecode), do: {:ok, timecode}
+
+  def cast(json) when is_map(json) do
+    schema = %{
+      smpte_timecode: :string,
+      rate: Framerate
+    }
+
+    changeset =
+      {%{}, schema}
+      |> Changeset.cast(json, [:smpte_timecode, :rate])
+      |> Changeset.validate_required([:smpte_timecode, :rate])
+
+    with {:ok, %{smpte_timecode: timecode_str, rate: rate}} <- Changeset.apply_action(changeset, :loaded),
+         {:ok, _} = result <- Timecode.with_frames(%TimecodeStr{in: timecode_str}, rate) do
+      result
+    else
+      _ -> :error
+    end
+  end
+
+  def cast(_), do: :error
+
+  # Handles converting database records into Ratio structs to be used by the
+  # application.
+  @doc false
+  @impl Ecto.Type
+  @spec load(db_record()) :: {:ok, Timecode.t()} | :error
+  def load({seconds, rate}) do
+    with {:ok, seconds} <- PgRational.load(seconds),
+         {:ok, framerate} <- PgFramerate.load(rate),
+         {:ok, _} = result <- Timecode.with_seconds(seconds, framerate, round: :off) do
+      result
+    else
+      _ -> :error
+    end
+  end
+
+  def load(_), do: :error
+
+  # Handles converting Ratio structs into database records.
+  @doc false
+  @impl Ecto.Type
+  @spec dump(Timecode.t()) :: {:ok, db_record()} | :error
+  def dump(%Timecode{} = timecode) do
+    with {:ok, seconds} <- PgRational.dump(timecode.seconds),
+         {:ok, framerate} <- PgFramerate.dump(timecode.rate) do
+      {:ok, {seconds, framerate}}
+    end
+  end
+
+  def dump(_), do: :error
+end

--- a/lib/ecto/postgres/pg_timecode_migrations.ex
+++ b/lib/ecto/postgres/pg_timecode_migrations.ex
@@ -1,0 +1,159 @@
+use Vtc.Ecto.Postgres.Utils
+
+defpgmodule Vtc.Ecto.Postgres.PgTimecode.Migrations do
+  @moduledoc """
+  Migrations for adding timecode types, functions and constraints to a
+  Postgres database.
+  """
+  alias Ecto.Migration
+
+  require Ecto.Migration
+
+  @doc section: :migrations_full
+  @doc """
+  Adds raw SQL queries to a migration for creating the database types, associated
+  functions, casts, operators, and operator families.
+
+  Safe to run multiple times when new functionality is added in updates to this library.
+  Existing values will be skipped.
+
+  ## Types Created
+
+  Calling this macro creates the following type definitions:
+
+  ```sql
+  CREATE TYPE timecode AS (
+    seconds rational,
+    rate framerate
+  );
+  ```
+
+  ## Schemas Created
+
+  Up to two schemas are created as detailed by the
+  [Configuring Database Objects](Vtc.Ecto.Postgres.PgTimecode.Migrations.html#create_all/0-configuring-database-objects)
+  section below.
+
+  ## Configuring Database Objects
+
+  To change where supporting functions are created, add the following to your
+  Repo confiugration:
+
+  ```elixir
+  config :vtc, Vtc.Test.Support.Repo,
+    adapter: Ecto.Adapters.Postgres,
+    ...
+    vtc: [
+      pg_timecode: [
+        functions_schema: :timecode,
+        functions_private_schema: :timecode_private,
+        functions_prefix: "timecode"
+      ]
+    ]
+  ```
+
+  Option definitions are as follows:
+
+  - `functions_schema`: The schema for "public" functions that will have backwards
+    compatibility guarantees and application code support. Default: `:public`.
+
+  - `functions_private_schema:` The schema for for developer-only "private" functions
+    that support the functions in the "timecode" schema. Will NOT have backwards
+    compatibility guarantees NOR application code support. Default: `:public`.
+
+  - `functions_prefix`: A prefix to add before all functions. Defaults to "timecode"
+    for any function created in the "public" schema, and "" otherwise.
+
+  ## Examples
+
+  ```elixir
+  defmodule MyMigration do
+    use Ecto.Migration
+
+    alias Vtc.Ecto.Postgres.PgTimecode
+    require PgTimecode.Migrations
+
+    def change do
+      PgTimecode.Migrations.create_all()
+    end
+  end
+  ```
+  """
+  @spec create_all() :: :ok
+  def create_all do
+    :ok = create_type_timecode()
+    :ok = create_function_schemas()
+
+    :ok
+  end
+
+  @doc section: :migrations_types
+  @doc """
+  Adds `timecode` composite type.
+  """
+  @spec create_type_timecode() :: :ok
+  def create_type_timecode do
+    :ok =
+      Migration.execute("""
+        DO $$ BEGIN
+          CREATE TYPE timecode AS (
+            seconds rational,
+            rate framerate
+          );
+          EXCEPTION WHEN duplicate_object
+            THEN null;
+        END $$;
+      """)
+
+    :ok
+  end
+
+  @doc section: :migrations_types
+  @doc """
+  Creates schemas to act as namespaces for rational functions:
+
+  - `timecode`: for user-facing "public" functions that will have backwards
+    compatibility guarantees and application code support.
+
+  - `timecode_private`: for developer-only "private" functions that support the
+    functions in the "timecode" schema. Will NOT have backwards compatibility guarantees
+    NOR application code support.
+
+  These schemas can be configured in your Repo settings.
+  """
+  @spec create_function_schemas() :: :ok
+  def create_function_schemas do
+    functions_schema = get_config(Migration.repo(), :functions_schema, :public)
+
+    if functions_schema != :public do
+      :ok =
+        Migration.execute("""
+          DO $$ BEGIN
+            CREATE SCHEMA #{functions_schema};
+            EXCEPTION WHEN duplicate_schema
+              THEN null;
+          END $$;
+        """)
+    end
+
+    functions_private_schema = get_config(Migration.repo(), :functions_private_schema, :public)
+
+    if functions_private_schema != :public do
+      :ok =
+        Migration.execute("""
+          DO $$ BEGIN
+            CREATE SCHEMA #{functions_private_schema};
+            EXCEPTION WHEN duplicate_schema
+              THEN null;
+          END $$;
+        """)
+    end
+
+    :ok
+  end
+
+  # Fetches PgRational configuration option from `repo`'s configuration.
+  @spec get_config(Ecto.Repo.t(), atom(), Keyword.value()) :: Keyword.value()
+  defp get_config(repo, opt, default),
+    do: repo.config() |> Keyword.get(:vtc, []) |> Keyword.get(:pg_timecode) |> Keyword.get(opt, default)
+end

--- a/lib/range.ex
+++ b/lib/range.ex
@@ -56,7 +56,7 @@ defmodule Vtc.Range do
   ```elixir
   iex> tc_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> tc_out = Timecode.with_frames!("02:00:00:00", Rates.f23_98())
-  iex> 
+  iex>
   iex> result = Range.new(tc_in, tc_out)
   iex> inspect(result)
   "{:ok, <01:00:00:00 - 02:00:00:00 :exclusive <23.98 NTSC>>}"
@@ -66,7 +66,7 @@ defmodule Vtc.Range do
 
   ```elixir
   iex> tc_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
-  iex> 
+  iex>
   iex> result = Range.new(tc_in, "02:00:00:00")
   iex> inspect(result)
   "{:ok, <01:00:00:00 - 02:00:00:00 :exclusive <23.98 NTSC>>}"
@@ -76,7 +76,7 @@ defmodule Vtc.Range do
 
   ```elixir
   iex> tc_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
-  iex> 
+  iex>
   iex> result = Range.new(tc_in, "02:00:00:00", out_type: :inclusive)
   iex> inspect(result)
   "{:ok, <01:00:00:00 - 02:00:00:00 :inclusive <23.98 NTSC>>}"
@@ -143,7 +143,7 @@ defmodule Vtc.Range do
   ```elixir
   iex> start_tc = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> duration = Timecode.with_frames!("00:30:00:00", Rates.f23_98())
-  iex> 
+  iex>
   iex> result = Range.with_duration(start_tc, duration)
   iex> inspect(result)
   "{:ok, <01:00:00:00 - 01:30:00:00 :exclusive <23.98 NTSC>>}"
@@ -153,7 +153,7 @@ defmodule Vtc.Range do
 
   ```elixir
   iex> start_tc = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
-  iex> 
+  iex>
   iex> result = Range.with_duration(start_tc, "00:30:00:00")
   iex> inspect(result)
   "{:ok, <01:00:00:00 - 01:30:00:00 :exclusive <23.98 NTSC>>}"
@@ -163,7 +163,7 @@ defmodule Vtc.Range do
 
   ```elixir
   iex> start_tc = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
-  iex> 
+  iex>
   iex> result = Range.with_duration(start_tc, "00:30:00:00", out_type: :inclusive)
   iex> inspect(result)
   "{:ok, <01:00:00:00 - 01:29:59:23 :inclusive <23.98 NTSC>>}"
@@ -233,7 +233,7 @@ defmodule Vtc.Range do
   ```elixir
   iex> tc_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> range = Range.new!(tc_in, "02:00:00:00")
-  iex> 
+  iex>
   iex> result = Range.with_inclusive_out(range)
   iex> inspect(result)
   "<01:00:00:00 - 01:59:59:23 :inclusive <23.98 NTSC>>"
@@ -251,7 +251,7 @@ defmodule Vtc.Range do
   ```elixir
   iex> tc_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> range = Range.new!(tc_in, "02:00:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> result = Range.with_exclusive_out(range)
   iex> inspect(result)
   "<01:00:00:00 - 02:00:00:01 :exclusive <23.98 NTSC>>"
@@ -288,7 +288,7 @@ defmodule Vtc.Range do
   ```elixir
   iex> tc_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> range = Range.new!(tc_in, "01:30:00:00")
-  iex> 
+  iex>
   iex> result = Range.duration(range)
   iex> inspect(result)
   "<00:30:00:00 <23.98 NTSC>>"
@@ -310,7 +310,7 @@ defmodule Vtc.Range do
   ```elixir
   iex> tc_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> range = Range.new!(tc_in, "01:30:00:00")
-  iex> 
+  iex>
   iex> Range.contains?(range, "01:10:00:00")
   true
   iex> Range.contains?(range, "01:40:00:00")
@@ -339,7 +339,7 @@ defmodule Vtc.Range do
   ```elixir
   iex> a_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> a = Range.new!(a_in, "02:00:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> b_in = Timecode.with_frames!("01:50:00:00", Rates.f23_98())
   iex> b = Range.new!(b_in, "02:30:00:00", out_type: :inclusive)
   iex> Range.overlaps?(a, b)
@@ -349,7 +349,7 @@ defmodule Vtc.Range do
   ```elixir
   iex> a_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> a = Range.new!(a_in, "02:00:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> b_in = Timecode.with_frames!("02:10:00:00", Rates.f23_98())
   iex> b = Range.new!(b_in, "03:30:00:00", out_type: :inclusive)
   iex> Range.overlaps?(a, b)
@@ -381,10 +381,10 @@ defmodule Vtc.Range do
   ```elixir
   iex> a_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> a = Range.new!(a_in, "02:00:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> b_in = Timecode.with_frames!("01:50:00:00", Rates.f23_98())
   iex> b = Range.new!(b_in, "02:30:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> result = Range.intersection(a, b)
   iex> inspect(result)
   "{:ok, <01:50:00:00 - 02:00:00:00 :inclusive <23.98 NTSC>>}"
@@ -393,7 +393,7 @@ defmodule Vtc.Range do
   ```elixir
   iex> a_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> a = Range.new!(a_in, "02:00:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> b_in = Timecode.with_frames!("02:10:00:00", Rates.f23_98())
   iex> b = Range.new!(b_in, "03:30:00:00", out_type: :inclusive)
   iex> Range.intersection(a, b)
@@ -415,10 +415,10 @@ defmodule Vtc.Range do
   ```elixir
   iex> a_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> a = Range.new!(a_in, "02:00:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> b_in = Timecode.with_frames!("02:10:00:00", Rates.f23_98())
   iex> b = Range.new!(b_in, "03:30:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> result = Range.intersection!(a, b)
   iex> inspect(result)
   "<00:00:00:00 - -00:00:00:01 :inclusive <23.98 NTSC>>"
@@ -446,10 +446,10 @@ defmodule Vtc.Range do
   ```elixir
   iex> a_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> a = Range.new!(a_in, "02:00:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> b_in = Timecode.with_frames!("02:10:00:00", Rates.f23_98())
   iex> b = Range.new!(b_in, "03:30:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> result = Range.separation(a, b)
   iex> inspect(result)
   "{:ok, <02:00:00:01 - 02:09:59:23 :inclusive <23.98 NTSC>>}"
@@ -458,7 +458,7 @@ defmodule Vtc.Range do
   ```elixir
   iex> a_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> a = Range.new!(a_in, "02:00:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> b_in = Timecode.with_frames!("01:50:00:00", Rates.f23_98())
   iex> b = Range.new!(b_in, "02:30:00:00", out_type: :inclusive)
   iex> Range.separation(a, b)
@@ -480,10 +480,10 @@ defmodule Vtc.Range do
   ```elixir
   iex> a_in = Timecode.with_frames!("01:00:00:00", Rates.f23_98())
   iex> a = Range.new!(a_in, "02:00:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> b_in = Timecode.with_frames!("01:50:00:00", Rates.f23_98())
   iex> b = Range.new!(b_in, "02:30:00:00", out_type: :inclusive)
-  iex> 
+  iex>
   iex> result = Range.separation!(a, b)
   iex> inspect(result)
   "<00:00:00:00 - -00:00:00:01 :inclusive <23.98 NTSC>>"

--- a/lib/timecode_parse_error.ex
+++ b/lib/timecode_parse_error.ex
@@ -21,7 +21,9 @@ defmodule Vtc.Timecode.ParseError do
   @typedoc """
   Type of `Timecode.ParseError`.
   """
-  @type t() :: %__MODULE__{reason: :unrecognized_format | :bad_drop_frames}
+  @type t() :: %__MODULE__{
+          reason: :unrecognized_format | :bad_drop_frames | :drop_frame_maximum_exceeded | :partial_frame
+        }
 
   @doc """
   Returns a message for the error reason.
@@ -31,4 +33,11 @@ defmodule Vtc.Timecode.ParseError do
 
   def message(%{reason: :bad_drop_frames}),
     do: "frames value not allowed for drop-frame timecode. frame should have been dropped"
+
+  def message(%{reason: :partial_frame}),
+    do:
+      "`seconds` is not cleanly divisible by `rate.playback`." <>
+        " This check can be turned off by setting `:allow_partial_frames?` to `true`"
+
+  def message(%{reason: :drop_frame_maximum_exceeded}), do: "frame number exceeded 24 hours for drop-frame timecode"
 end

--- a/lib/utils/drop_frame.ex
+++ b/lib/utils/drop_frame.ex
@@ -50,12 +50,8 @@ defmodule Vtc.Utils.DropFrame do
     framerate = Ratio.to_float(rate.playback)
 
     dropped_per_min = round(framerate * 0.066666)
-    frames_per_hour = round(framerate * 60 * 60)
-    frames_per_24_hours = frames_per_hour * 24
     frames_per_10_min = round(framerate * 60 * 10)
     frames_per_min = round(framerate) * 60 - dropped_per_min
-
-    frame_number = rem(frame_number, frames_per_24_hours)
 
     tens_of_mins = div(frame_number, frames_per_10_min)
     remaining_mins = rem(frame_number, frames_per_10_min)
@@ -92,4 +88,11 @@ defmodule Vtc.Utils.DropFrame do
       _ -> false
     end
   end
+
+  @doc """
+  Drop-frame timecode CANNOT exceed the 24-hour mark. This method calculates the maximum
+  number of frames that can exist within a day.
+  """
+  @spec max_frames(Framerate.t()) :: pos_integer()
+  def max_frames(%{ntsc: :drop} = rate), do: round(Ratio.to_float(rate.playback) * 60.0 * 60.0) * 24
 end

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Vtc.MixProject do
       start_permanent: Mix.env() == :prod,
       package: package(),
       deps: deps(),
-      dialyzer: [plt_add_apps: Enum.map(deps(), &elem(&1, 0))]
+      dialyzer: [plt_add_apps: Enum.map(deps(), &elem(&1, 0)) ++ [:ex_unit]]
     ]
   end
 

--- a/priv/repo/migrations/20230625235804_add_timecode_type.exs
+++ b/priv/repo/migrations/20230625235804_add_timecode_type.exs
@@ -1,0 +1,11 @@
+defmodule Vtc.Test.Support.Repo.Migrations.AddTimecodeType do
+  @moduledoc false
+  use Ecto.Migration
+
+  alias Vtc.Ecto.Postgres.PgTimecode
+
+  def change do
+    :ok = PgTimecode.Migrations.create_all()
+    :ok = PgTimecode.Migrations.create_all()
+  end
+end

--- a/priv/repo/migrations/20230626000041_add_timecode_schemas.exs
+++ b/priv/repo/migrations/20230626000041_add_timecode_schemas.exs
@@ -1,0 +1,14 @@
+defmodule Vtc.Test.Support.Repo.Migrations.AddTimecodeSchemas do
+  @moduledoc false
+  use Ecto.Migration
+
+  alias Vtc.Ecto.Postgres.PgTimecode
+
+  def change do
+    create table("timecodes_01", primary_key: false) do
+      add(:id, :uuid, primary_key: true, null: false)
+      add(:a, PgTimecode.type())
+      add(:b, PgTimecode.type())
+    end
+  end
+end

--- a/test/ecto/postgres/pg_framerate_test.exs
+++ b/test/ecto/postgres/pg_framerate_test.exs
@@ -1,10 +1,9 @@
-defmodule Vtc.Ecto.Postgres.FramerateTest do
+defmodule Vtc.Ecto.Postgres.PgFramerateTest do
   use Vtc.Test.Support.EctoCase, async: true
   use ExUnitProperties
 
   alias Ecto.Changeset
   alias Ecto.Query
-  alias Vtc.Ecto.Postgres.Framerate
   alias Vtc.Framerate
   alias Vtc.Rates
   alias Vtc.Test.Support.FramerateSchema01
@@ -172,7 +171,7 @@ defmodule Vtc.Ecto.Postgres.FramerateTest do
     end
   end
 
-  serilization_table = [
+  serialization_table = [
     %{
       application_value: Rates.f23_98(),
       database_record: {{24_000, 1001}, ["non_drop"]}
@@ -192,7 +191,7 @@ defmodule Vtc.Ecto.Postgres.FramerateTest do
   ]
 
   describe "#dump/1" do
-    table_test "succeeds on <%= application_value %>", serilization_table, test_case do
+    table_test "succeeds on <%= application_value %>", serialization_table, test_case do
       %{application_value: application_value, database_record: database_record} = test_case
 
       assert {:ok, result} = Framerate.dump(application_value)
@@ -222,7 +221,7 @@ defmodule Vtc.Ecto.Postgres.FramerateTest do
   end
 
   describe "#load/1" do
-    table_test "<%= application_value %>", serilization_table, test_case do
+    table_test "<%= application_value %>", serialization_table, test_case do
       %{application_value: application_value, database_record: database_record} = test_case
 
       assert {:ok, result} = Framerate.load(database_record)
@@ -259,21 +258,21 @@ defmodule Vtc.Ecto.Postgres.FramerateTest do
       assert db_record == expected
     end
 
-    table_test "placeholder | <%= application_value %>", serilization_table, test_case do
+    table_test "placeholder | <%= application_value %>", serialization_table, test_case do
       %{application_value: application_value, database_record: database_record} = test_case
 
       query = Query.from(f in fragment("SELECT ? as r", type(^application_value, Framerate)), select: f.r)
       assert Repo.one!(query) == database_record
     end
 
-    table_test "playback field | <%= application_value %>", serilization_table, test_case do
+    table_test "playback field | <%= application_value %>", serialization_table, test_case do
       %{database_record: {expected, _}, application_value: application_value} = test_case
 
       query = Query.from(f in fragment("SELECT (?).playback as r", type(^application_value, Framerate)), select: f.r)
       assert Repo.one!(query) == expected
     end
 
-    table_test "tags field | <%= application_value %>", serilization_table, test_case do
+    table_test "tags field | <%= application_value %>", serialization_table, test_case do
       %{database_record: {_, expected}, application_value: application_value} = test_case
 
       query = Query.from(f in fragment("SELECT (?).tags as r", type(^application_value, Framerate)), select: f.r)
@@ -290,7 +289,7 @@ defmodule Vtc.Ecto.Postgres.FramerateTest do
   end
 
   describe "#table serialization" do
-    table_test "can insert into field without constraints", serilization_table, test_case do
+    table_test "can insert into field without constraints", serialization_table, test_case do
       %{application_value: application_value} = test_case
 
       assert {:ok, inserted} =
@@ -307,7 +306,7 @@ defmodule Vtc.Ecto.Postgres.FramerateTest do
       assert record.b == nil
     end
 
-    table_test "can insert into field with constraints", serilization_table, test_case do
+    table_test "can insert into field with constraints", serialization_table, test_case do
       %{application_value: application_value} = test_case
 
       assert {:ok, inserted} =

--- a/test/ecto/postgres/pg_timecode_test.exs
+++ b/test/ecto/postgres/pg_timecode_test.exs
@@ -1,0 +1,332 @@
+defmodule Vtc.Ecto.Postgres.PgTimecodeTest do
+  use Vtc.Test.Support.EctoCase, async: true
+  use ExUnitProperties
+
+  alias Ecto.Changeset
+  alias Ecto.Query
+  alias Vtc.Rates
+  alias Vtc.Test.Support.TimecodeSchema01
+  alias Vtc.TestUtls.StreamDataVtc
+  alias Vtc.Timecode
+
+  require Query
+
+  describe "#cast/1" do
+    cast_table = [
+      %{
+        input: %{
+          smpte_timecode: "01:00:00:00",
+          rate: %{
+            playback: [24_000, 1001],
+            ntsc: :non_drop
+          }
+        },
+        expected: Timecode.with_frames!("01:00:00:00", Rates.f23_98())
+      },
+      %{
+        input: %{
+          smpte_timecode: "-01:00:00:00",
+          rate: %{
+            playback: "24000/1001",
+            ntsc: :non_drop
+          }
+        },
+        expected: Timecode.with_frames!("-01:00:00:00", Rates.f23_98())
+      },
+      %{
+        input: %{
+          smpte_timecode: "01:00:00:00",
+          rate: %{
+            playback: [30_000, 1001],
+            ntsc: :drop
+          }
+        },
+        expected: Timecode.with_frames!("01:00:00:00", Rates.f29_97_df())
+      },
+      %{
+        input: %{
+          smpte_timecode: "-01:00:00:00",
+          rate: %{
+            playback: [30_000, 1001],
+            ntsc: :drop
+          }
+        },
+        expected: Timecode.with_frames!("-01:00:00:00", Rates.f29_97_df())
+      },
+      %{
+        input: %{
+          smpte_timecode: "01:00:00:00",
+          rate: %{
+            playback: [30_000, 1001],
+            ntsc: "non_drop"
+          }
+        },
+        expected: Timecode.with_frames!("01:00:00:00", Rates.f29_97_ndf())
+      }
+    ]
+
+    table_test "<%= expected %>", cast_table, test_case do
+      %{input: input, expected: expected} = test_case
+      assert {:ok, ^expected} = Timecode.cast(input)
+    end
+
+    table_test "<%= expected %> | string keys", cast_table, test_case do
+      %{input: input, expected: expected} = test_case
+      input = convert_input_to_string_keys(input)
+
+      assert {:ok, ^expected} = Timecode.cast(input)
+    end
+
+    table_test "<%= expected %> | through changeset", cast_table, test_case do
+      %{input: input, expected: expected} = test_case
+
+      assert {:ok, record} =
+               %TimecodeSchema01{}
+               |> TimecodeSchema01.changeset(%{a: input, b: input})
+               |> Changeset.apply_action(:test)
+
+      assert record.a == expected
+      assert record.b == expected
+    end
+
+    table_test "<%= expected %> | through changeset | string keys", cast_table, test_case do
+      %{input: input, expected: expected} = test_case
+      input = convert_input_to_string_keys(input)
+
+      assert {:ok, record} =
+               %TimecodeSchema01{}
+               |> TimecodeSchema01.changeset(%{a: input, b: input})
+               |> Changeset.apply_action(:test)
+
+      assert record.a == expected
+      assert record.b == expected
+    end
+
+    # Converts the input for a test cast from atom keys to string keys
+    @spec convert_input_to_string_keys(%{atom() => any()}) :: %{String.t() => any()}
+    defp convert_input_to_string_keys(input) do
+      input =
+        Map.update(input, :rate, %{}, fn rate_map ->
+          rate_map |> Enum.map(fn {key, value} -> {Atom.to_string(key), value} end) |> Map.new()
+        end)
+
+      input |> Enum.map(fn {key, value} -> {Atom.to_string(key), value} end) |> Map.new()
+    end
+
+    bad_cast_table = [
+      %{
+        name: "feet+frames",
+        input: %{
+          smpte_timecode: "01+04",
+          rate: %{
+            playback: [24_000, 1001],
+            ntsc: :non_drop
+          }
+        }
+      },
+      %{
+        name: "frames integer",
+        input: %{
+          smpte_timecode: 24,
+          rate: %{
+            playback: [24_000, 1001],
+            ntsc: :non_drop
+          }
+        }
+      },
+      %{
+        name: "float",
+        input: %{
+          smpte_timecode: 24.0,
+          rate: %{
+            playback: [24_000, 1001],
+            ntsc: :non_drop
+          }
+        }
+      },
+      %{
+        name: "ratio",
+        input: %{
+          smpte_timecode: Ratio.new(24, 1),
+          rate: %{
+            playback: [24_000, 1001],
+            ntsc: :non_drop
+          }
+        }
+      },
+      %{
+        name: "bad framerate",
+        input: %{
+          smpte_timecode: "01:00:00:00",
+          rate: %{
+            playback: [30_000, 1002],
+            ntsc: :drop
+          }
+        }
+      }
+    ]
+
+    table_test "fails on <%= name %>", bad_cast_table, test_case do
+      %{input: input} = test_case
+      assert :error = Timecode.cast(input)
+    end
+
+    property "succeeds on good timecode json" do
+      check all(timecode <- StreamDataVtc.timecode(rate_opts: [type: [:whole, :drop, :non_drop]])) do
+        input = %{
+          smpte_timecode: Timecode.timecode(timecode),
+          rate: %{
+            playback: [timecode.rate.playback.numerator, timecode.rate.playback.denominator],
+            ntsc: timecode.rate.ntsc
+          }
+        }
+
+        timecode_str = Timecode.timecode(timecode)
+        assert {:ok, parsed} = Timecode.with_frames(timecode_str, timecode.rate)
+        assert parsed == timecode
+
+        assert {:ok, result} = Timecode.cast(input)
+        assert result == timecode
+      end
+    end
+  end
+
+  serialization_table = [
+    %{
+      app_value: Timecode.with_frames!("01:00:00:00", Rates.f23_98()),
+      db_value: {{18_018, 5}, {{24_000, 1001}, ["non_drop"]}}
+    },
+    %{
+      app_value: Timecode.with_frames!("-01:00:00:00", Rates.f23_98()),
+      db_value: {{-18_018, 5}, {{24_000, 1001}, ["non_drop"]}}
+    },
+    %{
+      app_value: Timecode.with_frames!("01:00:00:00", Rates.f29_97_df()),
+      db_value: {{8_999_991, 2500}, {{30_000, 1001}, ["drop"]}}
+    },
+    %{
+      app_value: Timecode.with_frames!("-01:00:00:00", Rates.f29_97_df()),
+      db_value: {{-8_999_991, 2500}, {{30_000, 1001}, ["drop"]}}
+    },
+    %{
+      app_value: Timecode.with_frames!("01:00:00:00", Rates.f24()),
+      db_value: {{3600, 1}, {{24, 1}, []}}
+    },
+    %{
+      app_value: Timecode.with_frames!("-01:00:00:00", Rates.f24()),
+      db_value: {{-3600, 1}, {{24, 1}, []}}
+    }
+  ]
+
+  describe "#dump/1" do
+    table_test "succeeds on <%= app_value %>", serialization_table, test_case do
+      %{db_value: db_value, app_value: app_value} = test_case
+      assert {:ok, ^db_value} = Timecode.dump(app_value)
+    end
+
+    bad_dump_table = [
+      %{input: "01:00:00:00"},
+      %{input: Ratio.new(3600, 1)},
+      %{input: {"01:00:00:00", Rates.f23_98()}},
+      %{input: {{-3600, 1}, {{24, 1}, []}}}
+    ]
+
+    table_test "fails on <%= input %>", bad_dump_table, test_case do
+      %{input: input} = test_case
+      assert :error = Timecode.dump(input)
+    end
+  end
+
+  describe "#load/1" do
+    table_test "succeeds on <%= app_value %>", serialization_table, test_case do
+      %{db_value: db_value, app_value: app_value} = test_case
+      assert {:ok, ^app_value} = Timecode.load(db_value)
+    end
+
+    bad_load_table = [
+      %{name: "bad drop framerate", input: {{8_999_991, 2500}, {{30_000, 1002}, ["drop"]}}},
+      %{name: "negative framerate", input: {{-3600, 1}, {{-24, 1}, []}}},
+      %{name: "non-rounded ntsc", input: {{1, 1}, {{24_000, 1001}, ["non_drop"]}}},
+      %{name: "non-rounded whole", input: {{24_000, 1001}, {{24, 1}, []}}}
+    ]
+
+    table_test "fails on <%= name %>", bad_load_table, test_case do
+      %{input: input} = test_case
+      assert :error = Timecode.load(input)
+    end
+  end
+
+  property "dump/1 -> load/1 round trip" do
+    check all(timecode <- StreamDataVtc.timecode()) do
+      assert {:ok, dumped} = Timecode.dump(timecode)
+      assert {:ok, ^timecode} = Timecode.load(dumped)
+    end
+  end
+
+  describe "#SELECT" do
+    table_test "placeholder | <%= app_value %>", serialization_table, test_case do
+      %{app_value: app_value, db_value: db_value} = test_case
+
+      query = Query.from(f in fragment("SELECT ? as r", type(^app_value, Timecode)), select: f.r)
+      assert Repo.one!(query) == db_value
+    end
+
+    table_test "seconds field | <%= app_value %>", serialization_table, test_case do
+      %{db_value: {expected, _}, app_value: app_value} = test_case
+
+      query = Query.from(f in fragment("SELECT (?).seconds as r", type(^app_value, Timecode)), select: f.r)
+      assert Repo.one!(query) == expected
+    end
+
+    table_test "rate field | <%= app_value %>", serialization_table, test_case do
+      %{db_value: {_, expected}, app_value: app_value} = test_case
+
+      query = Query.from(f in fragment("SELECT (?).rate as r", type(^app_value, Timecode)), select: f.r)
+      assert Repo.one!(query) == expected
+    end
+
+    property "succeeds on good timecode" do
+      check all(timecode <- StreamDataVtc.timecode()) do
+        query = Query.from(f in fragment("SELECT ? as r", type(^timecode, Timecode)), select: f.r)
+        assert record = Repo.one!(query)
+        assert {:ok, ^timecode} = Timecode.load(record)
+      end
+    end
+  end
+
+  describe "#table serialization" do
+    table_test "can insert into field without constraints", serialization_table, test_case do
+      %{app_value: app_value} = test_case
+
+      assert {:ok, inserted} =
+               %TimecodeSchema01{}
+               |> TimecodeSchema01.changeset(%{a: app_value})
+               |> Repo.insert()
+
+      assert %TimecodeSchema01{} = inserted
+      assert inserted.a == app_value
+      assert inserted.b == nil
+
+      assert %TimecodeSchema01{} = record = Repo.get(TimecodeSchema01, inserted.id)
+      assert record.a == app_value
+      assert record.b == nil
+    end
+
+    property "succeeds on good timecode" do
+      check all(timecode <- StreamDataVtc.timecode()) do
+        assert {:ok, inserted} =
+                 %TimecodeSchema01{}
+                 |> TimecodeSchema01.changeset(%{a: timecode, b: timecode})
+                 |> Repo.insert()
+
+        assert %TimecodeSchema01{} = inserted
+        assert inserted.a == timecode
+        assert inserted.b == timecode
+
+        assert %TimecodeSchema01{} = record = Repo.get(TimecodeSchema01, inserted.id)
+        assert record.a == timecode
+        assert record.b == timecode
+      end
+    end
+  end
+end

--- a/test/support/timecode_schema_01.ex
+++ b/test/support/timecode_schema_01.ex
@@ -1,0 +1,25 @@
+defmodule Vtc.Test.Support.TimecodeSchema01 do
+  @moduledoc """
+  Dummy schema for verifying the Postgres Repo in our test env
+  """
+  use Ecto.Schema
+
+  alias Ecto.Changeset
+  alias Vtc.Timecode
+
+  @type t() :: %__MODULE__{
+          id: Ecto.UUID.t(),
+          a: Timecode.t(),
+          b: Timecode.t()
+        }
+
+  @primary_key {:id, Ecto.UUID, autogenerate: true}
+
+  schema "timecodes_01" do
+    field(:a, Timecode)
+    field(:b, Timecode)
+  end
+
+  @spec changeset(%__MODULE__{}, %{atom() => any()}) :: Changeset.t(%__MODULE__{})
+  def changeset(schema, attrs), do: Changeset.cast(schema, attrs, [:a, :b])
+end

--- a/test/timecode/timecode_ops_test.exs
+++ b/test/timecode/timecode_ops_test.exs
@@ -392,12 +392,20 @@ defmodule Vtc.TimecodeTest.Ops do
       assert Timecode.add(a, b, round: :ceil) == expected
     end
 
-    test "round | :off" do
+    test "round | :off | allow_partial_frames" do
       a = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
       b = %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()}
       expected = %Timecode{seconds: Ratio.new(235, 240), rate: Rates.f24()}
 
-      assert Timecode.add(a, b, round: :off) == expected
+      assert Timecode.add(a, b, round: :off, allow_partial_frames?: true) == expected
+    end
+
+    test "error | round | :off" do
+      a = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
+      b = %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()}
+
+      error = assert_raise Timecode.ParseError, fn -> Timecode.add(a, b, round: :off) end
+      assert error.reason == :partial_frame
     end
   end
 
@@ -520,12 +528,20 @@ defmodule Vtc.TimecodeTest.Ops do
       assert Timecode.sub(a, b, round: :ceil) == expected
     end
 
-    test "round | :off" do
+    test "round | :off | allow_partial_frames" do
       a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
       b = %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()}
       expected = %Timecode{seconds: Ratio.new(235, 240), rate: Rates.f24()}
 
-      assert Timecode.sub(a, b, round: :off) == expected
+      assert Timecode.sub(a, b, round: :off, allow_partial_frames?: true) == expected
+    end
+
+    test "error | round | :off" do
+      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      b = %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()}
+
+      error = assert_raise Timecode.ParseError, fn -> Timecode.sub(a, b, round: :off) end
+      assert error.reason == :partial_frame
     end
   end
 
@@ -606,12 +622,20 @@ defmodule Vtc.TimecodeTest.Ops do
       assert Timecode.mult(a, b, round: :ceil) == expected
     end
 
-    test "round | :off" do
+    test "round | :off | allow_partial_frames" do
       a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
       b = Ratio.new(239, 240)
       expected = %Timecode{seconds: Ratio.new(239, 240), rate: Rates.f24()}
 
-      assert Timecode.mult(a, b, round: :off) == expected
+      assert Timecode.mult(a, b, round: :off, allow_partial_frames?: true) == expected
+    end
+
+    test "error | round | :off" do
+      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      b = Ratio.new(239, 240)
+
+      error = assert_raise Timecode.ParseError, fn -> Timecode.mult(a, b, round: :off) end
+      assert error.reason == :partial_frame
     end
   end
 
@@ -687,12 +711,20 @@ defmodule Vtc.TimecodeTest.Ops do
       assert Timecode.div(a, b, round: :ceil) == expected
     end
 
-    test "round | :off" do
+    test "round | :off | allow_partial_frames" do
       a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
       b = 48
       expected = %Timecode{seconds: Ratio.new(1, 48), rate: Rates.f24()}
 
-      assert Timecode.div(a, b, round: :off) == expected
+      assert Timecode.div(a, b, round: :off, allow_partial_frames?: true) == expected
+    end
+
+    test "error | round | :off" do
+      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      b = 48
+
+      error = assert_raise Timecode.ParseError, fn -> Timecode.div(a, b, round: :off) end
+      assert error.reason == :partial_frame
     end
   end
 


### PR DESCRIPTION
- Adds PgTimecode ecto type
- Fix bug where drop-frame timecodes approaching 24 hours were not being handled appropriately.
- Add error when trying to construct drop-frame timecodes over "24:00:00:00".