### PR TITLE
Add PgTimecode constraints

### DIFF
--- a/lib/ecto/postgres/pg_framerate_migrations.ex
+++ b/lib/ecto/postgres/pg_framerate_migrations.ex
@@ -7,6 +7,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   """
   alias Ecto.Migration
   alias Ecto.Migration.Constraint
+  alias Vtc.Ecto.Postgres
 
   require Ecto.Migration
 
@@ -91,7 +92,10 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   def create_all do
     :ok = create_type_framerate_tags()
     :ok = create_type_framerate()
+
     :ok = create_function_schemas()
+
+    :ok = create_func_is_ntsc()
 
     :ok
   end
@@ -138,8 +142,9 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
 
   @doc section: :migrations_types
   @doc """
-  Creates schemas to act as namespaces for framerate functions based on your repo's
-  settings.
+  Up to two schemas are created as detailed by the
+  [Configuring Database Objects](Vtc.Ecto.Postgres.PgFramerate.Migrations.html#create_all/0-configuring-database-objects)
+  section above.
   """
   @spec create_function_schemas() :: :ok
   def create_function_schemas do
@@ -172,39 +177,84 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
     :ok
   end
 
+  @doc section: :migrations_functions
+  @doc """
+  Creates `rational_private.simplify(rat)` function that simplifies a rational. Used at
+  the end of every rational operation to avoid overflows.
+  """
+  @spec create_func_is_ntsc() :: :ok
+  def create_func_is_ntsc do
+    create_func =
+      Postgres.Utils.create_plpgsql_function(
+        :"#{function(:is_ntsc, Migration.repo())}",
+        args: [input: :framerate],
+        returns: :boolean,
+        body: """
+        RETURN (
+          (input).tags @> '{drop}'::framerate_tags[]
+          OR (input).tags @> '{non_drop}'::framerate_tags[]
+        );
+        """
+      )
+
+    :ok = Migration.execute(create_func)
+
+    :ok
+  end
+
   @doc section: :migrations_constraints
   @doc """
-  Creates basic constraints for a [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`)
-  database field.
+  Creates basic constraints for a [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`) /
+  [Framerate](`Vtc.Framerate`) database field.
+
+  ## Arguments
+
+  - `table`: The table to make the constraint on.
+
+  - `target_value`: The target value to check. Can be be any sql fragment that resolves
+    to a `framerate` value.
+
+  - `field`: The name of the field being validated. Can be omitted if `target_value`
+    is itself a field on `table`. This name is not used for anything but the constraint
+    names.
 
   ## Constraints created:
 
-  - `{field_name}_positive`: Checks that the playback speed is positive.
+  - `{field}_positive`: Checks that the playback speed is positive.
 
-  - `{field_name}_ntsc_tags`: Checks that only `drop` or `non_drop` is set.
+  - `{field}_ntsc_tags`: Checks that both `drop` and `non_drop` are not set at the same
+    time.
+
+  - `{field}_ntsc_valid`: Checks that NTSC framerates are mathematically sound, i.e.,
+    that the rate is equal to `(round(rate.playback) * 1000) / 1001`.
+
+  - `{field}_ntsc_drop_valid`: Checks that NTSC, drop-frame framerates are valid, i.e,
+    are cleanly divisible by `30_000/1001`.
 
   ## Examples
 
   ```elixir
   create table("my_table", primary_key: false) do
     add(:id, :uuid, primary_key: true, null: false)
-    add(:a, PgFramerate.type())
-    add(:b, PgFramerate.type())
+    add(:a, Framerate.type())
+    add(:b, Framerate.type())
   end
 
   PgRational.migration_add_field_constraints(:my_table, :a)
   PgRational.migration_add_field_constraints(:my_table, :b)
   ```
   """
-  @spec create_field_constraints(atom(), atom()) :: :ok
-  def create_field_constraints(table, field_name) do
+  @spec create_field_constraints(atom(), atom() | String.t(), atom() | String.t()) :: :ok
+  def create_field_constraints(table, target_value, field \\ nil) do
+    field = constraint_get_field_name(target_value, field)
+
     positive =
       Migration.constraint(
         table,
-        "#{field_name}_positive",
+        "#{field}_positive",
         check: """
-        (#{field_name}).playback.denominator > 0
-        AND (#{field_name}).playback.numerator > 0
+        (#{target_value}).playback.denominator > 0
+        AND (#{target_value}).playback.numerator > 0
         """
       )
 
@@ -213,18 +263,70 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
     ntsc_tags =
       Migration.constraint(
         table,
-        "#{field_name}_ntsc_tags",
+        "#{field}_ntsc_tags",
         check: """
         NOT (
-          ((#{field_name}).tags) @> '{drop}'::framerate_tags[]
-          AND ((#{field_name}).tags) @> '{non_drop}'::framerate_tags[]
+          ((#{target_value}).tags) @> '{drop}'::framerate_tags[]
+          AND ((#{target_value}).tags) @> '{non_drop}'::framerate_tags[]
         )
         """
       )
 
     %Constraint{} = Migration.create(ntsc_tags)
 
+    ntsc_valid =
+      Migration.constraint(
+        table,
+        "#{field}_ntsc_valid",
+        check: """
+        NOT #{function(:is_ntsc, Migration.repo())}(#{target_value})
+        OR (
+            (
+              round((#{target_value}).playback.numerator::float / (#{target_value}).playback.denominator::float) * 1000,
+              1001
+            )::rational
+            = (#{target_value}).playback
+        )
+        """
+      )
+
+    %Constraint{} = Migration.create(ntsc_valid)
+
+    drop_valid =
+      Migration.constraint(
+        table,
+        "#{field}_ntsc_drop_valid",
+        check: """
+        NOT (#{target_value}).tags @> '{drop}'::framerate_tags[]
+        OR (#{target_value}).playback % (30000, 1001)::rational = (0, 1)::rational
+        """
+      )
+
+    %Constraint{} = Migration.create(drop_valid)
+
     :ok
+  end
+
+  @spec constraint_get_field_name(atom() | String.t(), atom() | String.t()) :: atom() | String.t()
+  defp constraint_get_field_name(target, nil), do: target
+  defp constraint_get_field_name(_, field_name), do: field_name
+
+  @doc """
+  Returns the config-qualified name of the function for this type.
+  """
+  @spec function(atom(), Ecto.Repo.t()) :: String.t()
+  def function(name, repo), do: "#{function_prefix(repo)}#{name}"
+
+  @spec function_prefix(Ecto.Repo.t()) :: String.t()
+  defp function_prefix(repo) do
+    functions_schema = get_config(repo, :functions_schema, :public)
+    functions_prefix = get_config(repo, :functions_prefix, "")
+
+    functions_prefix = if functions_prefix == "" and functions_schema == :public, do: "rational", else: functions_prefix
+
+    functions_prefix = if functions_prefix == "", do: "", else: "#{functions_prefix}_"
+
+    "#{functions_schema}.#{functions_prefix}"
   end
 
   # Fetches PgRational configuration option from `repo`'s configuration.

--- a/lib/ecto/postgres/pg_framerate_migrations.ex
+++ b/lib/ecto/postgres/pg_framerate_migrations.ex
@@ -318,19 +318,9 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   def function(name, repo), do: "#{function_prefix(repo)}#{name}"
 
   @spec function_prefix(Ecto.Repo.t()) :: String.t()
-  defp function_prefix(repo) do
-    functions_schema = get_config(repo, :functions_schema, :public)
-    functions_prefix = get_config(repo, :functions_prefix, "")
-
-    functions_prefix = if functions_prefix == "" and functions_schema == :public, do: "rational", else: functions_prefix
-
-    functions_prefix = if functions_prefix == "", do: "", else: "#{functions_prefix}_"
-
-    "#{functions_schema}.#{functions_prefix}"
-  end
+  defp function_prefix(repo), do: Postgres.Utils.type_function_prefix(repo, :pg_framerate)
 
   # Fetches PgRational configuration option from `repo`'s configuration.
   @spec get_config(Ecto.Repo.t(), atom(), Keyword.value()) :: Keyword.value()
-  defp get_config(repo, opt, default),
-    do: repo.config() |> Keyword.get(:vtc, []) |> Keyword.get(:pg_framerate) |> Keyword.get(opt, default)
+  defp get_config(repo, opt, default), do: Postgres.Utils.get_type_config(repo, :pg_framerate, opt, default)
 end

--- a/lib/ecto/postgres/pg_framerate_migrations.ex
+++ b/lib/ecto/postgres/pg_framerate_migrations.ex
@@ -6,7 +6,6 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   Postgres database.
   """
   alias Ecto.Migration
-  alias Ecto.Migration.Constraint
   alias Vtc.Ecto.Postgres
 
   require Ecto.Migration
@@ -90,14 +89,12 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   """
   @spec create_all() :: :ok
   def create_all do
-    :ok = create_type_framerate_tags()
-    :ok = create_type_framerate()
+    create_type_framerate_tags()
+    create_type_framerate()
 
-    :ok = create_function_schemas()
+    create_function_schemas()
 
-    :ok = create_func_is_ntsc()
-
-    :ok
+    create_func_is_ntsc()
   end
 
   @doc section: :migrations_types
@@ -106,17 +103,16 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   """
   @spec create_type_framerate_tags() :: :ok
   def create_type_framerate_tags do
-    :ok =
-      Migration.execute("""
-        DO $$ BEGIN
-          CREATE TYPE framerate_tags AS ENUM (
-            'drop',
-            'non_drop'
-          );
-          EXCEPTION WHEN duplicate_object
-            THEN null;
-        END $$;
-      """)
+    Migration.execute("""
+      DO $$ BEGIN
+        CREATE TYPE framerate_tags AS ENUM (
+          'drop',
+          'non_drop'
+        );
+        EXCEPTION WHEN duplicate_object
+          THEN null;
+      END $$;
+    """)
   end
 
   @doc section: :migrations_types
@@ -125,19 +121,16 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   """
   @spec create_type_framerate() :: :ok
   def create_type_framerate do
-    :ok =
-      Migration.execute("""
-        DO $$ BEGIN
-          CREATE TYPE framerate AS (
-            playback rational,
-            tags framerate_tags[]
-          );
-          EXCEPTION WHEN duplicate_object
-            THEN null;
-        END $$;
-      """)
-
-    :ok
+    Migration.execute("""
+      DO $$ BEGIN
+        CREATE TYPE framerate AS (
+          playback rational,
+          tags framerate_tags[]
+        );
+        EXCEPTION WHEN duplicate_object
+          THEN null;
+      END $$;
+    """)
   end
 
   @doc section: :migrations_types
@@ -151,27 +144,25 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
     functions_schema = get_config(Migration.repo(), :functions_schema, :public)
 
     if functions_schema != :public do
-      :ok =
-        Migration.execute("""
-          DO $$ BEGIN
-            CREATE SCHEMA #{functions_schema};
-            EXCEPTION WHEN duplicate_schema
-              THEN null;
-          END $$;
-        """)
+      Migration.execute("""
+        DO $$ BEGIN
+          CREATE SCHEMA #{functions_schema};
+          EXCEPTION WHEN duplicate_schema
+            THEN null;
+        END $$;
+      """)
     end
 
     functions_private_schema = get_config(Migration.repo(), :functions_private_schema, :public)
 
     if functions_private_schema != :public do
-      :ok =
-        Migration.execute("""
-          DO $$ BEGIN
-            CREATE SCHEMA #{functions_private_schema};
-            EXCEPTION WHEN duplicate_schema
-              THEN null;
-          END $$;
-        """)
+      Migration.execute("""
+        DO $$ BEGIN
+          CREATE SCHEMA #{functions_private_schema};
+          EXCEPTION WHEN duplicate_schema
+            THEN null;
+        END $$;
+      """)
     end
 
     :ok
@@ -197,9 +188,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_constraints
@@ -258,7 +247,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
         """
       )
 
-    %Constraint{} = Migration.create(positive)
+    Migration.create(positive)
 
     ntsc_tags =
       Migration.constraint(
@@ -272,7 +261,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
         """
       )
 
-    %Constraint{} = Migration.create(ntsc_tags)
+    Migration.create(ntsc_tags)
 
     ntsc_valid =
       Migration.constraint(
@@ -290,7 +279,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
         """
       )
 
-    %Constraint{} = Migration.create(ntsc_valid)
+    Migration.create(ntsc_valid)
 
     drop_valid =
       Migration.constraint(
@@ -302,7 +291,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
         """
       )
 
-    %Constraint{} = Migration.create(drop_valid)
+    Migration.create(drop_valid)
 
     :ok
   end

--- a/lib/ecto/postgres/pg_rational_migrations.ex
+++ b/lib/ecto/postgres/pg_rational_migrations.ex
@@ -380,7 +380,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   @doc section: :migrations_functions
   @doc """
-  Creates Creates `rational_private.add(a, b)` backing function for the `+` operator
+  Creates `rational_private.add(a, b)` backing function for the `+` operator
   between two rationals.
   """
   @spec create_func_add() :: :ok

--- a/lib/ecto/postgres/pg_rational_migrations.ex
+++ b/lib/ecto/postgres/pg_rational_migrations.ex
@@ -6,6 +6,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   Postgres database.
   """
   alias Ecto.Migration
+  alias Ecto.Migration.Constraint
   alias Vtc.Ecto.Postgres
 
   require Ecto.Migration
@@ -105,48 +106,46 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   """
   @spec create_all() :: :ok
   def create_all do
-    :ok = create_type()
-    :ok = create_function_schemas()
+    create_type()
+    create_function_schemas()
 
-    :ok = create_func_greatest_common_denominator()
-    :ok = create_func_simplify()
+    create_func_greatest_common_denominator()
+    create_func_simplify()
 
-    :ok = create_func_minus()
-    :ok = create_func_abs()
-    :ok = create_func_round()
-    :ok = create_func_add()
-    :ok = create_func_sub()
-    :ok = create_func_mult()
-    :ok = create_func_div()
-    :ok = create_func_modulo()
+    create_func_minus()
+    create_func_abs()
+    create_func_round()
+    create_func_add()
+    create_func_sub()
+    create_func_mult()
+    create_func_div()
+    create_func_modulo()
 
-    :ok = create_op_add()
-    :ok = create_op_sub()
-    :ok = create_op_mult()
-    :ok = create_op_div()
-    :ok = create_op_modulo()
+    create_op_add()
+    create_op_sub()
+    create_op_mult()
+    create_op_div()
+    create_op_modulo()
 
-    :ok = create_func_cmp()
-    :ok = create_func_eq()
-    :ok = create_func_neq()
-    :ok = create_func_lt()
-    :ok = create_func_lte()
-    :ok = create_func_gt()
-    :ok = create_func_gte()
+    create_func_cmp()
+    create_func_eq()
+    create_func_neq()
+    create_func_lt()
+    create_func_lte()
+    create_func_gt()
+    create_func_gte()
 
-    :ok = create_op_eq()
-    :ok = create_op_neq()
-    :ok = create_op_neq2()
-    :ok = create_op_lt()
-    :ok = create_op_lte()
-    :ok = create_op_gt()
-    :ok = create_op_gte()
-    :ok = create_op_class_btree()
+    create_op_eq()
+    create_op_neq()
+    create_op_neq2()
+    create_op_lt()
+    create_op_lte()
+    create_op_gt()
+    create_op_gte()
+    create_op_class_btree()
 
-    :ok = create_func_cast_to_double_precison()
-    :ok = create_cast_double_precision()
-
-    :ok
+    create_func_cast_to_double_precison()
+    create_cast_double_precision()
   end
 
   @doc section: :migrations_types
@@ -159,19 +158,16 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   """
   @spec create_type() :: :ok
   def create_type do
-    :ok =
-      Migration.execute("""
-        DO $$ BEGIN
-          CREATE TYPE rational AS (
-            numerator bigint,
-            denominator bigint
-          );
-          EXCEPTION WHEN duplicate_object
-            THEN null;
-        END $$;
-      """)
-
-    :ok
+    Migration.execute("""
+      DO $$ BEGIN
+        CREATE TYPE rational AS (
+          numerator bigint,
+          denominator bigint
+        );
+        EXCEPTION WHEN duplicate_object
+          THEN null;
+      END $$;
+    """)
   end
 
   @doc section: :migrations_types
@@ -185,27 +181,25 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     functions_schema = get_config(Migration.repo(), :functions_schema, :public)
 
     if functions_schema != :public do
-      :ok =
-        Migration.execute("""
-          DO $$ BEGIN
-            CREATE SCHEMA #{functions_schema};
-            EXCEPTION WHEN duplicate_schema
-              THEN null;
-          END $$;
-        """)
+      Migration.execute("""
+        DO $$ BEGIN
+          CREATE SCHEMA #{functions_schema};
+          EXCEPTION WHEN duplicate_schema
+            THEN null;
+        END $$;
+      """)
     end
 
     functions_private_schema = get_config(Migration.repo(), :functions_private_schema, :public)
 
     if functions_private_schema != :public do
-      :ok =
-        Migration.execute("""
-          DO $$ BEGIN
-            CREATE SCHEMA #{functions_private_schema};
-            EXCEPTION WHEN duplicate_schema
-              THEN null;
-          END $$;
-        """)
+      Migration.execute("""
+        DO $$ BEGIN
+          CREATE SCHEMA #{functions_private_schema};
+          EXCEPTION WHEN duplicate_schema
+            THEN null;
+        END $$;
+      """)
     end
 
     :ok
@@ -237,9 +231,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -270,9 +262,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -292,9 +282,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -314,9 +302,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -350,9 +336,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -371,9 +355,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   ## ARITHMATIC BACKING FUNCS
@@ -400,9 +382,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -427,9 +407,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -454,9 +432,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -481,9 +457,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -517,9 +491,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   ## COMPARISON BACKING FUNCS
@@ -559,9 +531,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -580,9 +550,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -601,9 +569,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -622,9 +588,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -648,9 +612,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -669,9 +631,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_functions
@@ -695,9 +655,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   ## ARITHMATIC OPS
@@ -717,9 +675,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         commutator: :+
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   @doc section: :migrations_operators
@@ -736,9 +692,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         :"#{private_function_prefix(Migration.repo())}sub"
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   @doc section: :migrations_operators
@@ -756,9 +710,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         commutator: :*
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   @doc section: :migrations_operators
@@ -775,9 +727,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         :"#{private_function_prefix(Migration.repo())}div"
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   @doc section: :migrations_operators
@@ -794,9 +744,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         :"#{private_function_prefix(Migration.repo())}modulo"
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   ## COMPARISON OPS
@@ -817,9 +765,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         negator: :<>
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   @doc section: :migrations_operators
@@ -838,9 +784,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         negator: :=
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   @doc section: :migrations_operators
@@ -859,9 +803,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         negator: :=
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   @doc section: :migrations_operators
@@ -880,9 +822,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         negator: :>=
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   @doc section: :migrations_operators
@@ -901,9 +841,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         negator: :>
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   @doc section: :migrations_operators
@@ -922,9 +860,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         negator: :<=
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   @doc section: :migrations_operators
@@ -943,9 +879,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         negator: :<
       )
 
-    :ok = Migration.execute(create_op)
-
-    :ok
+    Migration.execute(create_op)
   end
 
   ## OPERATOR CLASSES
@@ -968,9 +902,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         ]
       )
 
-    :ok = Migration.execute(create_class)
-
-    :ok
+    Migration.execute(create_class)
   end
 
   ## CASTS
@@ -992,9 +924,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         :"#{private_function_prefix(Migration.repo())}cast_to_float"
       )
 
-    :ok = Migration.execute(create_cast)
-
-    :ok
+    Migration.execute(create_cast)
   end
 
   @doc section: :migrations_constraints
@@ -1021,7 +951,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   """
   @spec create_field_constraints(atom(), atom()) :: :ok
   def create_field_constraints(table, field_name) do
-    Migration.create(
+    constraint =
       Migration.constraint(
         table,
         "#{field_name}_denominator_positive",
@@ -1029,7 +959,8 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
         (#{field_name}).denominator > 0
         """
       )
-    )
+
+    %Constraint{} = Migration.create(constraint)
 
     :ok
   end

--- a/lib/ecto/postgres/pg_rational_migrations.ex
+++ b/lib/ecto/postgres/pg_rational_migrations.ex
@@ -1034,24 +1034,6 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     :ok
   end
 
-  # Fetches PgRational configuration option from `repo`'s configuration.
-  @spec get_config(Ecto.Repo.t(), atom(), Keyword.value()) :: Keyword.value()
-  defp get_config(repo, opt, default),
-    do: repo.config() |> Keyword.get(:vtc, []) |> Keyword.get(:pg_rational) |> Keyword.get(opt, default)
-
-  @spec private_function_prefix(Ecto.Repo.t()) :: String.t()
-  defp private_function_prefix(repo) do
-    functions_private_schema = get_config(repo, :functions_private_schema, :public)
-    functions_prefix = get_config(repo, :functions_prefix, "")
-
-    functions_prefix =
-      if functions_prefix == "" and functions_private_schema == :public, do: "rational", else: functions_prefix
-
-    functions_prefix = if functions_prefix == "", do: "", else: "#{functions_prefix}_"
-
-    "#{functions_private_schema}.#{functions_prefix}"
-  end
-
   @doc """
   Returns the config-qualified name of the function for this type.
   """
@@ -1059,14 +1041,12 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   def function(name, repo), do: "#{function_prefix(repo)}#{name}"
 
   @spec function_prefix(Ecto.Repo.t()) :: String.t()
-  defp function_prefix(repo) do
-    functions_schema = get_config(repo, :functions_schema, :public)
-    functions_prefix = get_config(repo, :functions_prefix, "")
+  defp function_prefix(repo), do: Postgres.Utils.type_function_prefix(repo, :pg_rational)
 
-    functions_prefix = if functions_prefix == "" and functions_schema == :public, do: "rational", else: functions_prefix
+  @spec private_function_prefix(Ecto.Repo.t()) :: String.t()
+  defp private_function_prefix(repo), do: Postgres.Utils.type_private_function_prefix(repo, :pg_rational)
 
-    functions_prefix = if functions_prefix == "", do: "", else: "#{functions_prefix}_"
-
-    "#{functions_schema}.#{functions_prefix}"
-  end
+  # Fetches PgRational configuration option from `repo`'s configuration.
+  @spec get_config(Ecto.Repo.t(), atom(), Keyword.value()) :: Keyword.value()
+  defp get_config(repo, opt, default), do: Postgres.Utils.get_type_config(repo, :pg_rational, opt, default)
 end

--- a/lib/ecto/postgres/pg_timecode_migrations.ex
+++ b/lib/ecto/postgres/pg_timecode_migrations.ex
@@ -159,12 +159,8 @@ defpgmodule Vtc.Ecto.Postgres.PgTimecode.Migrations do
         declares: [rounded: :bigint],
         returns: :timecode,
         body: """
-        IF (rate).playback > (1, 1)::rational AND (seconds % (rate).playback) = (0, 1)::rational THEN
-          RETURN (seconds, rate);
-        ELSE
-          SELECT #{rational_round}((rate).playback * seconds) INTO rounded;
-          RETURN (((rounded, 1)::rational / (rate).playback), rate);
-        END IF;
+        SELECT #{rational_round}((rate).playback * seconds) INTO rounded;
+        RETURN (((rounded, 1)::rational / (rate).playback), rate);
         """
       )
 

--- a/lib/ecto/postgres/pg_timecode_migrations.ex
+++ b/lib/ecto/postgres/pg_timecode_migrations.ex
@@ -6,7 +6,6 @@ defpgmodule Vtc.Ecto.Postgres.PgTimecode.Migrations do
   Postgres database.
   """
   alias Ecto.Migration
-  alias Ecto.Migration.Constraint
   alias Vtc.Ecto.Postgres
   alias Vtc.Ecto.Postgres.PgFramerate
   alias Vtc.Ecto.Postgres.PgRational
@@ -85,12 +84,10 @@ defpgmodule Vtc.Ecto.Postgres.PgTimecode.Migrations do
   """
   @spec create_all() :: :ok
   def create_all do
-    :ok = create_type_timecode()
-    :ok = create_function_schemas()
+    create_type_timecode()
+    create_function_schemas()
 
-    :ok = create_func_with_seconds()
-
-    :ok
+    create_func_with_seconds()
   end
 
   @doc section: :migrations_types
@@ -99,19 +96,16 @@ defpgmodule Vtc.Ecto.Postgres.PgTimecode.Migrations do
   """
   @spec create_type_timecode() :: :ok
   def create_type_timecode do
-    :ok =
-      Migration.execute("""
-        DO $$ BEGIN
-          CREATE TYPE timecode AS (
-            seconds rational,
-            rate framerate
-          );
-          EXCEPTION WHEN duplicate_object
-            THEN null;
-        END $$;
-      """)
-
-    :ok
+    Migration.execute("""
+      DO $$ BEGIN
+        CREATE TYPE timecode AS (
+          seconds rational,
+          rate framerate
+        );
+        EXCEPTION WHEN duplicate_object
+          THEN null;
+      END $$;
+    """)
   end
 
   @doc section: :migrations_types
@@ -125,27 +119,25 @@ defpgmodule Vtc.Ecto.Postgres.PgTimecode.Migrations do
     functions_schema = get_config(Migration.repo(), :functions_schema, :public)
 
     if functions_schema != :public do
-      :ok =
-        Migration.execute("""
-          DO $$ BEGIN
-            CREATE SCHEMA #{functions_schema};
-            EXCEPTION WHEN duplicate_schema
-              THEN null;
-          END $$;
-        """)
+      Migration.execute("""
+        DO $$ BEGIN
+          CREATE SCHEMA #{functions_schema};
+          EXCEPTION WHEN duplicate_schema
+            THEN null;
+        END $$;
+      """)
     end
 
     functions_private_schema = get_config(Migration.repo(), :functions_private_schema, :public)
 
     if functions_private_schema != :public do
-      :ok =
-        Migration.execute("""
-          DO $$ BEGIN
-            CREATE SCHEMA #{functions_private_schema};
-            EXCEPTION WHEN duplicate_schema
-              THEN null;
-          END $$;
-        """)
+      Migration.execute("""
+        DO $$ BEGIN
+          CREATE SCHEMA #{functions_private_schema};
+          EXCEPTION WHEN duplicate_schema
+            THEN null;
+        END $$;
+      """)
     end
 
     :ok
@@ -176,9 +168,7 @@ defpgmodule Vtc.Ecto.Postgres.PgTimecode.Migrations do
         """
       )
 
-    :ok = Migration.execute(create_func)
-
-    :ok
+    Migration.execute(create_func)
   end
 
   @doc section: :migrations_constraints
@@ -217,7 +207,7 @@ defpgmodule Vtc.Ecto.Postgres.PgTimecode.Migrations do
   """
   @spec create_field_constraints(atom(), atom()) :: :ok
   def create_field_constraints(table, field) do
-    :ok = PgFramerate.Migrations.create_field_constraints(table, "(#{field}).rate", :"#{field}_rate")
+    PgFramerate.Migrations.create_field_constraints(table, "(#{field}).rate", :"#{field}_rate")
 
     seconds_divisible_by_rate =
       Migration.constraint(
@@ -228,7 +218,7 @@ defpgmodule Vtc.Ecto.Postgres.PgTimecode.Migrations do
         """
       )
 
-    %Constraint{} = Migration.create(seconds_divisible_by_rate)
+    Migration.create(seconds_divisible_by_rate)
 
     :ok
   end

--- a/lib/ecto/postgres/pg_utils.ex
+++ b/lib/ecto/postgres/pg_utils.ex
@@ -107,7 +107,7 @@ defmodule Vtc.Ecto.Postgres.Utils do
 
   - `body`: The function body.
   """
-  @spec create_plpgsql_function(atom(), create_func_opts()) :: raw_sql()
+  @spec create_plpgsql_function(String.t(), create_func_opts()) :: raw_sql()
   def create_plpgsql_function(name, opts) do
     args = Keyword.get(opts, :args, [])
     returns = Keyword.fetch!(opts, :returns)
@@ -158,7 +158,7 @@ defmodule Vtc.Ecto.Postgres.Utils do
   @doc """
   Builds an SQL query for creating a new native operator.
   """
-  @spec create_operator(atom(), atom(), atom(), atom(), commutator: atom(), negator: atom()) :: raw_sql()
+  @spec create_operator(atom(), atom(), atom(), String.t(), commutator: atom(), negator: atom()) :: raw_sql()
   def create_operator(name, left_type, right_type, func_name, opts \\ []) do
     commutator = Keyword.get(opts, :commutator)
     negator = Keyword.get(opts, :negator)
@@ -184,7 +184,8 @@ defmodule Vtc.Ecto.Postgres.Utils do
   @doc """
   Builds an SQL query for creating a new native CAST
   """
-  @spec create_operator_class(atom(), atom(), atom(), Keyword.t(pos_integer()), Keyword.t(pos_integer())) :: raw_sql()
+  @spec create_operator_class(atom(), atom(), atom(), Keyword.t(pos_integer()), [{String.t(), pos_integer()}]) ::
+          raw_sql()
   def create_operator_class(name, type, index_type, operators, functions) do
     operators_sql_list =
       Enum.map(operators, fn {operator, index} ->
@@ -212,7 +213,7 @@ defmodule Vtc.Ecto.Postgres.Utils do
   @doc """
   Builds an SQL query for creating a new native CAST
   """
-  @spec create_cast(atom(), atom(), atom()) :: raw_sql()
+  @spec create_cast(atom(), atom(), atom() | String.t()) :: raw_sql()
   def create_cast(left_type, right_type, func_name) do
     """
     DO $wrapper$ BEGIN

--- a/lib/ecto/postgres/pg_utils.ex
+++ b/lib/ecto/postgres/pg_utils.ex
@@ -138,6 +138,7 @@ defmodule Vtc.Ecto.Postgres.Utils do
         CREATE FUNCTION #{name}(#{args})
           RETURNS #{returns}
           LANGUAGE plpgsql
+          STRICT
           IMMUTABLE
           LEAKPROOF
           PARALLEL SAFE

--- a/lib/timecode.ex
+++ b/lib/timecode.ex
@@ -143,10 +143,17 @@ defmodule Vtc.Timecode do
   @typedoc """
   Valid values for rounding options.
 
-  - `:closest`: Round the to the closet whole frame.
-  - `:floor`: Always round down to the closest whole-frame.
-  - `:ciel`: Always round up to the closest whole-frame.
-  - `:trunc`: Always round towards zero.
+  - `:closest`: Round the to the closet whole frame. Rounds away from zero when
+    value is equidistant from two whole-frames.
+
+  - `:floor`: Always round down to the closest whole-frame. Negative numbers round away
+     from zero
+
+  - `:ciel`: Always round up to the closest whole-frame. Negative numbers round towards
+     zero.
+
+  - `:trunc`: Always round towards zero to the closest whole frame. Negative numbers
+    round up and positive numbers round down.
   """
   @type round() :: :closest | :floor | :ceil | :trunc
 

--- a/lib/timecode.ex
+++ b/lib/timecode.ex
@@ -240,8 +240,11 @@ defmodule Vtc.Timecode do
   "<00:00:01:00 <23.98 NTSC>>"
   ```
   """
-  @spec with_seconds(Seconds.t(), Framerate.t(), opts :: [round: maybe_round(), allow_partial_frames?: boolean()]) ::
-          parse_result()
+  @spec with_seconds(
+          Seconds.t(),
+          Framerate.t(),
+          opts :: [round: maybe_round(), allow_partial_frames?: boolean()]
+        ) :: parse_result()
   def with_seconds(seconds, rate, opts \\ []) do
     round = Keyword.get(opts, :round, :closest)
     allow_partial_frames? = Keyword.get(opts, :allow_partial_frames?, false)
@@ -258,11 +261,14 @@ defmodule Vtc.Timecode do
   defp with_seconds_round_to_frame(seconds, _, :off), do: seconds
 
   defp with_seconds_round_to_frame(seconds, rate, round) do
-    case Ratio.div(seconds, rate.playback) do
-      %Ratio{denominator: 1} ->
+    divided = Ratio.div(seconds, rate.playback)
+    positive? = Ratio.gte?(rate.playback, %Ratio{numerator: 1, denominator: 1})
+
+    case {positive?, divided} do
+      {true, %{denominator: 1}} ->
         seconds
 
-      %Ratio{} ->
+      _ ->
         rate.playback
         |> Ratio.mult(seconds)
         |> Rational.round(round)

--- a/lib/utils/rational.ex
+++ b/lib/utils/rational.ex
@@ -36,7 +36,7 @@ defmodule Vtc.Utils.Rational do
   # implementation, only rounds up rather than down:
   # https://github.com/python/cpython/blob/3.11/Lib/fractions.py
   @spec round_closest(integer(), pos_integer()) :: integer()
-  defp round_closest(n, d) when n < 0, do: -round_closest(-n, d)
+  defp round_closest(n, d) when n * d < 0, do: -round_closest(-n, d)
   defp round_closest(n, d) when Kernel.rem(n, d) * 2 < d, do: div(n, d)
   defp round_closest(n, d), do: div(n, d) + 1
 

--- a/lib/utils/rational.ex
+++ b/lib/utils/rational.ex
@@ -1,6 +1,8 @@
 defmodule Vtc.Utils.Rational do
   @moduledoc false
 
+  import Kernel, except: [rem: 2]
+
   @doc """
   Rounds `x` based on `method`.
 
@@ -17,14 +19,17 @@ defmodule Vtc.Utils.Rational do
 
     - `:ciel`: Always round up to the closest whole-frame.
 
+    - `:trunc`: Always rounds towards zero.
+
     - `:off`: Pass value through without rounding.
   """
-  @spec round(Ratio.t(), :closest | :floor | :ceil) :: integer()
+  @spec round(Ratio.t(), :closest | :floor | :ceil | :trunc) :: integer()
   @spec round(Ratio.t(), :off) :: Ratio.t()
   def round(x, method \\ :closest)
   def round(%{numerator: n, denominator: d}, :closest), do: round_closest(n, d)
   def round(x, :floor), do: Ratio.floor(x)
   def round(x, :ceil), do: Ratio.ceil(x)
+  def round(x, :trunc), do: Ratio.trunc(x)
   def round(x, :off), do: x
 
   # Handles roundinf to the closest integer. Adapted loosly from Python's
@@ -32,7 +37,7 @@ defmodule Vtc.Utils.Rational do
   # https://github.com/python/cpython/blob/3.11/Lib/fractions.py
   @spec round_closest(integer(), pos_integer()) :: integer()
   defp round_closest(n, d) when n < 0, do: -round_closest(-n, d)
-  defp round_closest(n, d) when rem(n, d) * 2 < d, do: div(n, d)
+  defp round_closest(n, d) when Kernel.rem(n, d) * 2 < d, do: div(n, d)
   defp round_closest(n, d), do: div(n, d) + 1
 
   @doc """
@@ -40,17 +45,27 @@ defmodule Vtc.Utils.Rational do
   {whole_dividend, rational_remainder} tuple.
   """
   @spec divrem(Ratio.t(), Ratio.t() | number()) :: {integer(), Ratio.t()}
-  def divrem(x, divisor) when is_integer(x) and x < 0, do: divrem(%Ratio{numerator: x, denominator: 1}, divisor)
-
-  def divrem(%{numerator: n} = dividend, divisor) when n < 0,
-    do: dividend |> Ratio.abs() |> divrem(divisor) |> then(fn {q, r} -> {-q, r} end)
-
   def divrem(dividend, divisor) do
     dividend = Ratio.new(dividend)
     divisor = Ratio.new(divisor)
 
-    quotient = dividend |> Ratio.div(divisor) |> Ratio.floor()
-    remainder = Ratio.sub(dividend, Ratio.mult(divisor, Ratio.new(quotient)))
+    # Round towards zero instead of infinity
+    quotient = dividend |> Ratio.div(divisor) |> then(&div(&1.numerator, &1.denominator))
+    remainder = rem(dividend, divisor)
     {quotient, remainder}
+  end
+
+  @spec rem(Ratio.t(), Ratio.t()) :: Ratio.t()
+  def rem(dividend, divisor) do
+    numerator = Kernel.rem(dividend.numerator * divisor.denominator, divisor.numerator * dividend.denominator)
+    denominator = dividend.denominator * divisor.denominator
+
+    result = Ratio.new(numerator, denominator)
+
+    if dividend.numerator < 0 do
+      %Ratio{numerator: abs(result.numerator) * -1, denominator: result.denominator}
+    else
+      result
+    end
   end
 end

--- a/lib/utils/rational.ex
+++ b/lib/utils/rational.ex
@@ -46,7 +46,10 @@ defmodule Vtc.Utils.Rational do
     do: dividend |> Ratio.abs() |> divrem(divisor) |> then(fn {q, r} -> {-q, r} end)
 
   def divrem(dividend, divisor) do
-    quotient = dividend |> Ratio.new() |> Ratio.div(Ratio.new(divisor)) |> Ratio.floor()
+    dividend = Ratio.new(dividend)
+    divisor = Ratio.new(divisor)
+
+    quotient = dividend |> Ratio.div(divisor) |> Ratio.floor()
     remainder = Ratio.sub(dividend, Ratio.mult(divisor, Ratio.new(quotient)))
     {quotient, remainder}
   end

--- a/priv/repo/migrations/20230626000041_add_timecode_schemas.exs
+++ b/priv/repo/migrations/20230626000041_add_timecode_schemas.exs
@@ -10,5 +10,7 @@ defmodule Vtc.Test.Support.Repo.Migrations.AddTimecodeSchemas do
       add(:a, PgTimecode.type())
       add(:b, PgTimecode.type())
     end
+
+    :ok = PgTimecode.Migrations.create_field_constraints("timecodes_01", :b)
   end
 end

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [version]
-target = 0.10
+target = 0.11
 release =
 
 [testing]

--- a/test/ecto/postgres/pg_framerate_test.exs
+++ b/test/ecto/postgres/pg_framerate_test.exs
@@ -357,7 +357,7 @@ defmodule Vtc.Ecto.Postgres.PgFramerateTest do
       },
       %{
         name: "zero denominator",
-        value: "((24000, 0), '{non_drop}')",
+        value: "((24, 0), '{}')",
         field: :b,
         expected_code: :check_violation,
         expected_constraint: "b_positive"
@@ -370,23 +370,37 @@ defmodule Vtc.Ecto.Postgres.PgFramerateTest do
         expected_constraint: "b_positive"
       },
       %{
-        name: "bad tag with and without constraints",
+        name: "bad tag with constraints",
         value: "((24000, 1001), '{bad_tag}')",
         field: :b,
         expected_code: :invalid_text_representation
       },
       %{
+        name: "bad tag without constraints",
+        value: "((24000, 1001), '{bad_tag}')",
+        field: :a,
+        expected_code: :invalid_text_representation
+      },
+      %{
         name: "multiple ntsc tags",
-        value: "((24000, 1001), '{drop, non_drop}')",
+        value: "((30000, 1001), '{drop, non_drop}')",
         field: :b,
         expected_code: :check_violation,
         expected_constraint: "b_ntsc_tags"
       },
       %{
-        name: "bad tag with and without constraints",
-        value: "((24000, 1001), '{bad_tag}')",
-        field: :a,
-        expected_code: :invalid_text_representation
+        name: "bad ntsc rate",
+        value: "((24, 1), '{non_drop}')",
+        field: :b,
+        expected_code: :check_violation,
+        expected_constraint: "b_ntsc_valid"
+      },
+      %{
+        name: "bad drop rate",
+        value: "((24000, 1001), '{drop}')",
+        field: :b,
+        expected_code: :check_violation,
+        expected_constraint: "b_ntsc_drop_valid"
       }
     ]
 

--- a/test/ecto/postgres/pg_rational_test.exs
+++ b/test/ecto/postgres/pg_rational_test.exs
@@ -574,7 +574,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
               a <- StreamDataVtc.rational(),
               b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
             ) do
-        {_, expected} = Rational.divrem(a, b)
+        expected = Rational.rem(a, b)
 
         query =
           Query.from(f in fragment("SELECT ? % ? as r", type(^a, PgRational), type(^b, PgRational)),
@@ -599,7 +599,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
                |> Repo.one!()
                |> PgRational.load()
 
-      {_, expected} = Rational.divrem(Ratio.new(23, 8), Ratio.new(4, 5))
+      expected = Rational.rem(Ratio.new(23, 8), Ratio.new(4, 5))
       assert result == expected
     end
   end

--- a/test/ecto/postgres/pg_rational_test.exs
+++ b/test/ecto/postgres/pg_rational_test.exs
@@ -360,6 +360,52 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     end
   end
 
+  describe "Postgres rational.abs/1" do
+    property "matches Ratio" do
+      check all(input <- StreamDataVtc.rational()) do
+        query =
+          Query.from(f in fragment("SELECT rational.abs(?) as r", type(^input, PgRational)),
+            select: f.r
+          )
+
+        assert {:ok, result} = query |> Repo.one!() |> PgRational.load()
+        assert result == Ratio.abs(input)
+      end
+    end
+
+    test "can be used on table fields | negative" do
+      assert {:ok, %{id: record_id}} =
+               %RationalsSchema01{}
+               |> RationalsSchema01.changeset(%{a: Ratio.new(-3, 4), b: Ratio.new(1, 1)})
+               |> Repo.insert()
+
+      assert {:ok, result} =
+               RationalsSchema01
+               |> Query.select([r], fragment("rational.abs(?)", r.a))
+               |> Query.where([r], r.id == ^record_id)
+               |> Repo.one!()
+               |> PgRational.load()
+
+      assert result == Ratio.new(3, 4)
+    end
+
+    test "can be used on table fields | positive" do
+      assert {:ok, %{id: record_id}} =
+               %RationalsSchema01{}
+               |> RationalsSchema01.changeset(%{a: Ratio.new(3, 4), b: Ratio.new(1, 1)})
+               |> Repo.insert()
+
+      assert {:ok, result} =
+               RationalsSchema01
+               |> Query.select([r], fragment("rational.abs(?)", r.a))
+               |> Query.where([r], r.id == ^record_id)
+               |> Repo.one!()
+               |> PgRational.load()
+
+      assert result == Ratio.new(3, 4)
+    end
+  end
+
   describe "Postgres rational.round/1" do
     property "matches Ratio" do
       check all(input <- StreamDataVtc.rational()) do
@@ -519,6 +565,42 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
                |> PgRational.load()
 
       assert result == Ratio.new(115, 32)
+    end
+  end
+
+  describe "Postgres % (modulo)" do
+    property "matches Ratio" do
+      check all(
+              a <- StreamDataVtc.rational(),
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+            ) do
+        {_, expected} = Rational.divrem(a, b)
+
+        query =
+          Query.from(f in fragment("SELECT ? % ? as r", type(^a, PgRational), type(^b, PgRational)),
+            select: f.r
+          )
+
+        assert {:ok, result} = query |> Repo.one!() |> PgRational.load()
+        assert result == expected
+      end
+    end
+
+    test "can be used on table fields" do
+      assert {:ok, %{id: record_id}} =
+               %RationalsSchema02{}
+               |> RationalsSchema02.changeset(%{a: Ratio.new(23, 8), b: Ratio.new(4, 5)})
+               |> Repo.insert()
+
+      assert {:ok, result} =
+               RationalsSchema02
+               |> Query.select([r], fragment("? % ?", r.a, r.b))
+               |> Query.where([r], r.id == ^record_id)
+               |> Repo.one!()
+               |> PgRational.load()
+
+      {_, expected} = Rational.divrem(Ratio.new(23, 8), Ratio.new(4, 5))
+      assert result == expected
     end
   end
 

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -53,7 +53,8 @@ defmodule Vtc.Test.Support.TestCase do
     Enum.map(timecodes, fn {field_name, value} -> {field_name, setup_timecode(value)} end)
   end
 
-  @spec setup_timecode(Frames.t() | {Frames.t(), Framerate.t()}) :: Timecode.t()
+  @spec setup_timecode(Timecode.t() | Frames.t() | {Frames.t(), Framerate.t()}) :: Timecode.t()
+  defp setup_timecode(%Timecode{} = value), do: value
   defp setup_timecode({frames, rate}), do: Timecode.with_frames!(frames, rate)
   defp setup_timecode(frames), do: setup_timecode({frames, Rates.f23_98()})
 

--- a/test/timecode/timecode_ops_test.exs
+++ b/test/timecode/timecode_ops_test.exs
@@ -357,49 +357,70 @@ defmodule Vtc.TimecodeTest.Ops do
         a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
         opts: [],
-        description: " | round :closest implicit",
+        description: "round :closest implicit",
         expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(-5, 240), rate: Rates.f24()},
+        opts: [],
+        description: "round :closest implicit negative",
+        expected: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()}
       },
       %{
         a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
         opts: [round: :closest],
-        description: " | explicit",
+        description: "",
         expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(-5, 240), rate: Rates.f24()},
+        opts: [round: :closest],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()}
       },
       %{
         a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(4, 240), rate: Rates.f24()},
         opts: [round: :closest],
-        description: " | down",
+        description: "towards zero",
         expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(-4, 240), rate: Rates.f24()},
+        opts: [round: :closest],
+        description: "towards zero negative",
+        expected: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()}
       },
       %{
         a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
         opts: [round: :floor],
-        description: " | positive",
+        description: "positive",
         expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
       },
       %{
         a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(-9, 240), rate: Rates.f24()},
         opts: [round: :floor],
-        description: " | negative",
+        description: "negative",
         expected: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()}
       },
       %{
         a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(1, 240), rate: Rates.f24()},
         opts: [round: :ceil],
-        description: " | positive",
+        description: "positive",
         expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
       },
       %{
         a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(-1, 240), rate: Rates.f24()},
         opts: [round: :ceil],
-        description: " | negative",
+        description: "negative",
         expected: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()}
       },
       %{
@@ -413,19 +434,19 @@ defmodule Vtc.TimecodeTest.Ops do
         a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
         opts: [round: :trunc],
-        description: " | positive",
+        description: "positive",
         expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
       },
       %{
         a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(-9, 240), rate: Rates.f24()},
         opts: [round: :trunc],
-        description: " | negative",
+        description: "negative",
         expected: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()}
       }
     ]
 
-    table_test "opts: | <%= opts %><%= description %>", round_table, test_case do
+    table_test "opts: | <%= opts %> <%= description %>", round_table, test_case do
       %{a: a, b: b, opts: opts, expected: expected} = test_case
       assert Timecode.add(a, b, opts) == expected
     end
@@ -518,52 +539,103 @@ defmodule Vtc.TimecodeTest.Ops do
       assert Timecode.sub(a, b) == expected
     end
 
-    test "round | :closest | implied" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+    round_table = [
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
+        opts: [],
+        description: ":closest implicit",
+        expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
+        opts: [],
+        description: ":closest implicit negative",
+        expected: %Timecode{seconds: Ratio.new(-25, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
+        opts: [round: :closest],
+        description: "explicit",
+        expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
+        opts: [round: :closest],
+        description: "explicit negative",
+        expected: %Timecode{seconds: Ratio.new(-25, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(6, 240), rate: Rates.f24()},
+        opts: [round: :closest],
+        description: "towards zero",
+        expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(4, 240), rate: Rates.f24()},
+        opts: [round: :closest],
+        description: "towards zero negative",
+        expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(1, 240), rate: Rates.f24()},
+        opts: [round: :floor],
+        description: "postivie",
+        expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(1, 240), rate: Rates.f24()},
+        opts: [round: :floor],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-25, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
+        opts: [round: :ceil],
+        description: "postive",
+        expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
+        opts: [round: :ceil],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(1, 240), rate: Rates.f24()},
+        opts: [round: :trunc],
+        description: "positive",
+        expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
+        opts: [round: :trunc],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
+        opts: [round: :off, allow_partial_frames?: true],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(235, 240), rate: Rates.f24()}
+      }
+    ]
 
-      assert Timecode.sub(a, b) == expected
-    end
-
-    test "round | :closest | explicit" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-
-      assert Timecode.sub(a, b, round: :closest) == expected
-    end
-
-    test "round | :closest | down" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(6, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-
-      assert Timecode.sub(a, b, round: :closest) == expected
-    end
-
-    test "round | :floor" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(1, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-
-      assert Timecode.sub(a, b, round: :floor) == expected
-    end
-
-    test "round | :ceil" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-
-      assert Timecode.sub(a, b, round: :ceil) == expected
-    end
-
-    test "round | :off | allow_partial_frames" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(235, 240), rate: Rates.f24()}
-
-      assert Timecode.sub(a, b, round: :off, allow_partial_frames?: true) == expected
+    table_test "opts: | <%= opts %> <%= description %>", round_table, test_case do
+      %{a: a, b: b, opts: opts, expected: expected} = test_case
+      assert Timecode.sub(a, b, opts) == expected
     end
 
     test "error | round | :off" do

--- a/test/timecode/timecode_ops_test.exs
+++ b/test/timecode/timecode_ops_test.exs
@@ -600,7 +600,7 @@ defmodule Vtc.TimecodeTest.Ops do
         a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
         opts: [round: :ceil],
-        description: "postive",
+        description: "positive",
         expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
       },
       %{

--- a/test/timecode/timecode_ops_test.exs
+++ b/test/timecode/timecode_ops_test.exs
@@ -352,52 +352,82 @@ defmodule Vtc.TimecodeTest.Ops do
       assert Timecode.add(a, b) == expected
     end
 
-    test "round | :closest | implied" do
-      a = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+    round_table = [
+      %{
+        a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
+        opts: [],
+        description: " | round :closest implicit",
+        expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
+        opts: [round: :closest],
+        description: " | explicit",
+        expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(4, 240), rate: Rates.f24()},
+        opts: [round: :closest],
+        description: " | down",
+        expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
+        opts: [round: :floor],
+        description: " | positive",
+        expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(-9, 240), rate: Rates.f24()},
+        opts: [round: :floor],
+        description: " | negative",
+        expected: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(1, 240), rate: Rates.f24()},
+        opts: [round: :ceil],
+        description: " | positive",
+        expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(-1, 240), rate: Rates.f24()},
+        opts: [round: :ceil],
+        description: " | negative",
+        expected: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
+        opts: [round: :off, allow_partial_frames?: true],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(235, 240), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
+        opts: [round: :trunc],
+        description: " | positive",
+        expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(-9, 240), rate: Rates.f24()},
+        opts: [round: :trunc],
+        description: " | negative",
+        expected: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()}
+      }
+    ]
 
-      assert Timecode.add(a, b) == expected
-    end
-
-    test "round | :closest | explicit" do
-      a = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-
-      assert Timecode.add(a, b, round: :closest) == expected
-    end
-
-    test "round | :closest | down" do
-      a = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(4, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-
-      assert Timecode.add(a, b, round: :closest) == expected
-    end
-
-    test "round | :floor" do
-      a = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-
-      assert Timecode.add(a, b, round: :floor) == expected
-    end
-
-    test "round | :ceil" do
-      a = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(1, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-
-      assert Timecode.add(a, b, round: :ceil) == expected
-    end
-
-    test "round | :off | allow_partial_frames" do
-      a = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-      b = %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()}
-      expected = %Timecode{seconds: Ratio.new(235, 240), rate: Rates.f24()}
-
-      assert Timecode.add(a, b, round: :off, allow_partial_frames?: true) == expected
+    table_test "opts: | <%= opts %><%= description %>", round_table, test_case do
+      %{a: a, b: b, opts: opts, expected: expected} = test_case
+      assert Timecode.add(a, b, opts) == expected
     end
 
     test "error | round | :off" do

--- a/test/timecode/timecode_ops_test.exs
+++ b/test/timecode/timecode_ops_test.exs
@@ -757,12 +757,12 @@ defmodule Vtc.TimecodeTest.Ops do
       dividend: {"-01:00:00:01", Rates.f24()},
       divisor: 2,
       expected_quotient: {"-00:30:00:00", Rates.f24()},
-      expected_remainder: {"00:00:00:01", Rates.f24()}
+      expected_remainder: {"-00:00:00:01", Rates.f24()}
     },
     %{
       dividend: {"-01:00:00:01", Rates.f24()},
       divisor: -2,
-      expected_quotient: {"00:30:00:01", Rates.f24()},
+      expected_quotient: {"00:30:00:00", Rates.f24()},
       expected_remainder: {"-00:00:00:01", Rates.f24()}
     },
     %{

--- a/test/timecode/timecode_ops_test.exs
+++ b/test/timecode/timecode_ops_test.exs
@@ -399,7 +399,7 @@ defmodule Vtc.TimecodeTest.Ops do
         a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
         opts: [round: :floor],
-        description: "positive",
+        description: "",
         expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
       },
       %{
@@ -413,7 +413,7 @@ defmodule Vtc.TimecodeTest.Ops do
         a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(1, 240), rate: Rates.f24()},
         opts: [round: :ceil],
-        description: "positive",
+        description: "",
         expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
       },
       %{
@@ -425,16 +425,9 @@ defmodule Vtc.TimecodeTest.Ops do
       },
       %{
         a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
-        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
-        opts: [round: :off, allow_partial_frames?: true],
-        description: "",
-        expected: %Timecode{seconds: Ratio.new(235, 240), rate: Rates.f24()}
-      },
-      %{
-        a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
         opts: [round: :trunc],
-        description: "positive",
+        description: "",
         expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
       },
       %{
@@ -443,6 +436,20 @@ defmodule Vtc.TimecodeTest.Ops do
         opts: [round: :trunc],
         description: "negative",
         expected: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
+        opts: [round: :off, allow_partial_frames?: true],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(235, 240), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(-5, 240), rate: Rates.f24()},
+        opts: [round: :off, allow_partial_frames?: true],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-235, 240), rate: Rates.f24()}
       }
     ]
 
@@ -586,7 +593,7 @@ defmodule Vtc.TimecodeTest.Ops do
         a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(1, 240), rate: Rates.f24()},
         opts: [round: :floor],
-        description: "postivie",
+        description: "",
         expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
       },
       %{
@@ -600,7 +607,7 @@ defmodule Vtc.TimecodeTest.Ops do
         a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(9, 240), rate: Rates.f24()},
         opts: [round: :ceil],
-        description: "positive",
+        description: "",
         expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
       },
       %{
@@ -614,7 +621,7 @@ defmodule Vtc.TimecodeTest.Ops do
         a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
         b: %Timecode{seconds: Ratio.new(1, 240), rate: Rates.f24()},
         opts: [round: :trunc],
-        description: "positive",
+        description: "",
         expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
       },
       %{
@@ -630,6 +637,13 @@ defmodule Vtc.TimecodeTest.Ops do
         opts: [round: :off, allow_partial_frames?: true],
         description: "",
         expected: %Timecode{seconds: Ratio.new(235, 240), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()},
+        b: %Timecode{seconds: Ratio.new(5, 240), rate: Rates.f24()},
+        opts: [round: :off, allow_partial_frames?: true],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-245, 240), rate: Rates.f24()}
       }
     ]
 
@@ -684,52 +698,96 @@ defmodule Vtc.TimecodeTest.Ops do
       assert Timecode.mult(a, b) == expected
     end
 
-    test "round | :closest | implied" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = Ratio.new(235, 240)
-      expected = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+    round_table = [
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(235, 240),
+        opts: [],
+        description: ":closest implicit",
+        expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(-235, 240),
+        opts: [],
+        description: ":closest implicit negative",
+        expected: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(235, 240),
+        opts: [round: :closest],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(-235, 240),
+        opts: [round: :closest],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(234, 240),
+        opts: [round: :closest],
+        description: "towards zero",
+        expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(-234, 240),
+        opts: [round: :closest],
+        description: "towards zero negative",
+        expected: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(239, 240),
+        opts: [round: :floor],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(-231, 240),
+        opts: [round: :floor],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(231, 240),
+        opts: [round: :ceil],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(-239, 240),
+        opts: [round: :ceil],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(239, 240),
+        opts: [round: :off, allow_partial_frames?: true],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(239, 240), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: Ratio.new(-239, 240),
+        opts: [round: :off, allow_partial_frames?: true],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-239, 240), rate: Rates.f24()}
+      }
+    ]
 
-      assert Timecode.mult(a, b) == expected
-    end
-
-    test "round | :closest | explicit" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = Ratio.new(235, 240)
-      expected = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-
-      assert Timecode.mult(a, b, round: :closest) == expected
-    end
-
-    test "round | :closest | down" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = Ratio.new(234, 240)
-      expected = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-
-      assert Timecode.mult(a, b, round: :closest) == expected
-    end
-
-    test "round | :floor" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = Ratio.new(239, 240)
-      expected = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-
-      assert Timecode.mult(a, b, round: :floor) == expected
-    end
-
-    test "round | :ceil" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = Ratio.new(231, 240)
-      expected = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-
-      assert Timecode.mult(a, b, round: :ceil) == expected
-    end
-
-    test "round | :off | allow_partial_frames" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = Ratio.new(239, 240)
-      expected = %Timecode{seconds: Ratio.new(239, 240), rate: Rates.f24()}
-
-      assert Timecode.mult(a, b, round: :off, allow_partial_frames?: true) == expected
+    table_test "opts: | <%= opts %> <%= description %>", round_table, test_case do
+      %{a: a, b: b, opts: opts, expected: expected} = test_case
+      assert Timecode.mult(a, b, opts) == expected
     end
 
     test "error | round | :off" do
@@ -773,52 +831,82 @@ defmodule Vtc.TimecodeTest.Ops do
       assert Timecode.div(a, b) == expected
     end
 
-    test "round | :closest | explicit" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = 48
-      expected = %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
+    round_table = [
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: 48,
+        opts: [round: :closest],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()},
+        b: 48,
+        opts: [round: :closest],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-1, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: 48 * 2,
+        opts: [round: :closest],
+        description: "towards zero",
+        expected: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: -48 * 2,
+        opts: [round: :closest],
+        description: "towards zero negative",
+        expected: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: 36,
+        opts: [round: :floor],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: -36,
+        opts: [round: :floor],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(-1, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: 48 * 2,
+        opts: [round: :ceil],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: -48 * 2,
+        opts: [round: :ceil],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(0, 24), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: 48,
+        opts: [round: :off, allow_partial_frames?: true],
+        description: "",
+        expected: %Timecode{seconds: Ratio.new(1, 48), rate: Rates.f24()}
+      },
+      %{
+        a: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+        b: 48,
+        opts: [round: :off, allow_partial_frames?: true],
+        description: "negative",
+        expected: %Timecode{seconds: Ratio.new(1, 48), rate: Rates.f24()}
+      }
+    ]
 
-      assert Timecode.div(a, b, round: :closest) == expected
-    end
-
-    test "round | :closest | down" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = 48 * 2
-      expected = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
-
-      assert Timecode.div(a, b, round: :closest) == expected
-    end
-
-    test "round | :floor" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = 36
-      expected = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
-
-      assert Timecode.div(a, b, round: :floor) == expected
-    end
-
-    test "round | :floor | :implied" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = 36
-      expected = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
-
-      assert Timecode.div(a, b) == expected
-    end
-
-    test "round | :ceil" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = 48 * 2
-      expected = %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
-
-      assert Timecode.div(a, b, round: :ceil) == expected
-    end
-
-    test "round | :off | allow_partial_frames" do
-      a = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      b = 48
-      expected = %Timecode{seconds: Ratio.new(1, 48), rate: Rates.f24()}
-
-      assert Timecode.div(a, b, round: :off, allow_partial_frames?: true) == expected
+    table_test "opts: | <%= opts %> <%= description %>", round_table, test_case do
+      %{a: a, b: b, opts: opts, expected: expected} = test_case
+      assert Timecode.div(a, b, opts) == expected
     end
 
     test "error | round | :off" do
@@ -834,165 +922,281 @@ defmodule Vtc.TimecodeTest.Ops do
     %{
       dividend: {"01:00:00:00", Rates.f24()},
       divisor: 2,
-      expected_quotient: {"00:30:00:00", Rates.f24()},
-      expected_remainder: {"00:00:00:00", Rates.f24()}
+      expected_q: {"00:30:00:00", Rates.f24()},
+      expected_r: {"00:00:00:00", Rates.f24()}
     },
     %{
       dividend: {"-01:00:00:00", Rates.f24()},
       divisor: 2,
-      expected_quotient: {"-00:30:00:00", Rates.f24()},
-      expected_remainder: {"00:00:00:00", Rates.f24()}
+      expected_q: {"-00:30:00:00", Rates.f24()},
+      expected_r: {"00:00:00:00", Rates.f24()}
     },
     %{
       dividend: "01:00:00:00",
       divisor: 2,
-      expected_quotient: "00:30:00:00",
-      expected_remainder: "00:00:00:00"
+      expected_q: "00:30:00:00",
+      expected_r: "00:00:00:00"
     },
     %{
       dividend: {"01:00:00:01", Rates.f24()},
       divisor: 2,
-      expected_quotient: {"00:30:00:00", Rates.f24()},
-      expected_remainder: {"00:00:00:01", Rates.f24()}
+      expected_q: {"00:30:00:00", Rates.f24()},
+      expected_r: {"00:00:00:01", Rates.f24()}
     },
     %{
       dividend: {"-01:00:00:01", Rates.f24()},
       divisor: 2,
-      expected_quotient: {"-00:30:00:00", Rates.f24()},
-      expected_remainder: {"-00:00:00:01", Rates.f24()}
+      expected_q: {"-00:30:00:00", Rates.f24()},
+      expected_r: {"-00:00:00:01", Rates.f24()}
     },
     %{
       dividend: {"-01:00:00:01", Rates.f24()},
       divisor: -2,
-      expected_quotient: {"00:30:00:00", Rates.f24()},
-      expected_remainder: {"-00:00:00:01", Rates.f24()}
+      expected_q: {"00:30:00:00", Rates.f24()},
+      expected_r: {"-00:00:00:01", Rates.f24()}
     },
     %{
       dividend: "01:00:00:01",
       divisor: 2,
-      expected_quotient: "00:30:00:00",
-      expected_remainder: "00:00:00:01"
+      expected_q: "00:30:00:00",
+      expected_r: "00:00:00:01"
     },
     %{
       dividend: {"01:00:00:01", Rates.f24()},
       divisor: 4,
-      expected_quotient: {"00:15:00:00", Rates.f24()},
-      expected_remainder: {"00:00:00:01", Rates.f24()}
+      expected_q: {"00:15:00:00", Rates.f24()},
+      expected_r: {"00:00:00:01", Rates.f24()}
     },
     %{
       dividend: "01:00:00:01",
       divisor: 4,
-      expected_quotient: "00:15:00:00",
-      expected_remainder: "00:00:00:01"
+      expected_q: "00:15:00:00",
+      expected_r: "00:00:00:01"
     },
     %{
       dividend: "01:00:00:02",
       divisor: 4,
-      expected_quotient: "00:15:00:00",
-      expected_remainder: "00:00:00:02"
+      expected_q: "00:15:00:00",
+      expected_r: "00:00:00:02"
     },
     %{
       dividend: {"01:00:00:01", Rates.f24()},
       divisor: 1.5,
-      expected_quotient: {"00:40:00:00", Rates.f24()},
-      expected_remainder: {"00:00:00:01", Rates.f24()}
+      expected_q: {"00:40:00:00", Rates.f24()},
+      expected_r: {"00:00:00:01", Rates.f24()}
     },
     %{
       dividend: "01:00:00:01",
       divisor: 1.5,
-      expected_quotient: "00:40:00:00",
-      expected_remainder: "00:00:00:01"
+      expected_q: "00:40:00:00",
+      expected_r: "00:00:00:01"
+    }
+  ]
+
+  divrem_round_table = [
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: 1,
+      opts: [],
+      description: "round frames closest implicit",
+      expected_q: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(-47, 48), rate: Rates.f24()},
+      b: 1,
+      opts: [],
+      description: "round frames closest implicit negative",
+      expected_q: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: 1,
+      opts: [round_frames: :closest],
+      description: "",
+      expected_q: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(-47, 48), rate: Rates.f24()},
+      b: 1,
+      opts: [round_frames: :closest],
+      description: "negative",
+      expected_q: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(234, 240), rate: Rates.f24()},
+      b: 1,
+      opts: [round_frames: :closest],
+      description: "towards zero",
+      expected_q: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(-234, 240), rate: Rates.f24()},
+      b: 1,
+      opts: [round_frames: :closest],
+      description: "towards zero negative",
+      expected_q: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: 1,
+      opts: [round_frames: :floor],
+      description: "",
+      expected_q: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(-47, 48), rate: Rates.f24()},
+      b: 1,
+      opts: [round_frames: :floor],
+      description: "frames negative",
+      expected_q: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: -1,
+      opts: [round_frames: :floor],
+      description: "dvisor negative",
+      expected_q: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: 1,
+      opts: [round_frames: :ceil],
+      description: "",
+      expected_q: %Timecode{seconds: Ratio.new(1), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(-47, 48), rate: Rates.f24()},
+      b: 1,
+      opts: [round_frames: :ceil],
+      description: "frames negative",
+      expected_q: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: -1,
+      opts: [round_frames: :ceil],
+      description: "divisor negative",
+      expected_q: %Timecode{seconds: Ratio.new(-1), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(239, 240), rate: Rates.f24()},
+      b: 1,
+      opts: [round_frames: :trunc],
+      description: "",
+      expected_q: %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(-239, 240), rate: Rates.f24()},
+      b: 1,
+      opts: [round_frames: :trunc],
+      description: "dividend negative",
+      expected_q: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(239, 240), rate: Rates.f24()},
+      b: -1,
+      opts: [round_frames: :trunc],
+      description: "divisor negative",
+      expected_q: %Timecode{seconds: Ratio.new(-23, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: 5 / 3,
+      opts: [],
+      description: "rem closest implicit",
+      expected_q: %Timecode{seconds: Ratio.new(14, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: -5 / 3,
+      opts: [],
+      description: "rem closest implicit negative",
+      expected_q: %Timecode{seconds: Ratio.new(-14, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: 5 / 3,
+      opts: [round_remainder: :closest],
+      description: "",
+      expected_q: %Timecode{seconds: Ratio.new(14, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: -5 / 3,
+      opts: [round_remainder: :closest],
+      description: "divisor negative",
+      expected_q: %Timecode{seconds: Ratio.new(-14, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: 5 / 3,
+      opts: [round_remainder: :ceil],
+      description: "",
+      expected_q: %Timecode{seconds: Ratio.new(14, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: -5 / 3,
+      opts: [round_remainder: :ceil],
+      description: "divisor negative",
+      expected_q: %Timecode{seconds: Ratio.new(-14, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: 5 / 3,
+      opts: [round_remainder: :floor],
+      description: "",
+      expected_q: %Timecode{seconds: Ratio.new(14, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0, 24), rate: Rates.f24()}
+    },
+    %{
+      a: %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()},
+      b: -5 / 3,
+      opts: [round_remainder: :floor],
+      description: "divisor negative",
+      expected_q: %Timecode{seconds: Ratio.new(-14, 24), rate: Rates.f24()},
+      expected_r: %Timecode{seconds: Ratio.new(0, 24), rate: Rates.f24()}
     }
   ]
 
   describe "#divrem/2" do
     setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:dividend, :expected_quotient, :expected_remainder]
+    @describetag timecodes: [:dividend, :expected_q, :expected_r]
 
-    table_test "<%= dividend %> /% <%= divisor %> == <%= expected_quotient %>, <%= expected_remainder %>",
-               divrem_table,
-               test_case do
-      %{
-        dividend: dividend,
-        divisor: divisor,
-        expected_quotient: expected_quotient,
-        expected_remainder: expected_remainder
-      } = test_case
+    table_test "<%= dividend %> /% <%= divisor %> == <%= expected_q %>, <%= expected_r %>", divrem_table, test_case do
+      %{dividend: dividend, divisor: divisor, expected_q: expected_quotient, expected_r: expected_remainder} = test_case
 
       result = Timecode.divrem(dividend, divisor)
       assert result == {expected_quotient, expected_remainder}
     end
 
-    test "round | frames :closest | implicit" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 1
-      expected_q = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      expected_r = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
+    table_test "opts: | <%= opts %> <%= description %>", divrem_round_table, test_case do
+      %{a: a, b: b, opts: opts, expected_q: expected_quotient, expected_r: expected_remainder} = test_case
 
-      assert Timecode.divrem(a, b) == {expected_q, expected_r}
-    end
-
-    test "round | frames :closest | explicit" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 1
-      expected_q = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      expected_r = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
-
-      assert Timecode.divrem(a, b, round_frames: :closest) == {expected_q, expected_r}
-    end
-
-    test "round | frames :floor" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 1
-      expected_q = %Timecode{seconds: Ratio.new(23, 24), rate: Rates.f24()}
-      expected_r = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
-
-      assert Timecode.divrem(a, b, round_frames: :floor) == {expected_q, expected_r}
-    end
-
-    test "round | frames :ceil" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 1
-      expected_q = %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}
-      expected_r = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
-
-      assert Timecode.divrem(a, b, round_frames: :ceil) == {expected_q, expected_r}
-    end
-
-    test "round | rem :closest | implicit" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 5 / 3
-      expected_q = %Timecode{seconds: Ratio.new(14, 24), rate: Rates.f24()}
-      expected_r = %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
-
-      assert Timecode.divrem(a, b) == {expected_q, expected_r}
-    end
-
-    test "round | rem :closest | explicit" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 5 / 3
-      expected_q = %Timecode{seconds: Ratio.new(14, 24), rate: Rates.f24()}
-      expected_r = %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
-
-      assert Timecode.divrem(a, b, round_remainder: :closest) == {expected_q, expected_r}
-    end
-
-    test "round | rem :ceil" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 5 / 3
-      expected_q = %Timecode{seconds: Ratio.new(14, 24), rate: Rates.f24()}
-      expected_r = %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
-
-      assert Timecode.divrem(a, b, round_remainder: :ceil) == {expected_q, expected_r}
-    end
-
-    test "round | rem :floor" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 5 / 3
-      expected_q = %Timecode{seconds: Ratio.new(14, 24), rate: Rates.f24()}
-      expected_r = %Timecode{seconds: Ratio.new(0, 24), rate: Rates.f24()}
-
-      assert Timecode.divrem(a, b, round_remainder: :floor) == {expected_q, expected_r}
+      assert {quotient, remainder} = Timecode.divrem(a, b, opts)
+      assert quotient == expected_quotient
+      assert remainder == expected_remainder
     end
 
     test "round | frames :off | raises" do
@@ -1015,80 +1219,16 @@ defmodule Vtc.TimecodeTest.Ops do
 
   describe "#rem/2" do
     setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:dividend, :expected_quotient, :expected_remainder]
+    @describetag timecodes: [:dividend, :expected_q, :expected_r]
 
-    table_test "<%= dividend %> % <%= divisor %> == <%= expected_remainder %>", divrem_table, test_case do
-      %{
-        dividend: dividend,
-        divisor: divisor,
-        expected_remainder: expected
-      } = test_case
-
+    table_test "<%= dividend %> % <%= divisor %> == <%= expected_r %>", divrem_table, test_case do
+      %{dividend: dividend, divisor: divisor, expected_r: expected} = test_case
       assert Timecode.rem(dividend, divisor) == expected
     end
 
-    test "round | frames :closest | implicit" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 1
-      expected = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
-
-      assert Timecode.rem(a, b) == expected
-    end
-
-    test "round | frames :closest | explicit" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 1
-      expected = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
-
-      assert Timecode.rem(a, b, round_frames: :closest) == expected
-    end
-
-    test "round | frames :floor" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 1
-      expected = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
-
-      assert Timecode.rem(a, b, round_frames: :floor) == expected
-    end
-
-    test "round | frames :ceil" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 1
-      expected = %Timecode{seconds: Ratio.new(0), rate: Rates.f24()}
-
-      assert Timecode.rem(a, b, round_frames: :ceil) == expected
-    end
-
-    test "round | rem :closest | implicit" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 5 / 3
-      expected = %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
-
-      assert Timecode.rem(a, b) == expected
-    end
-
-    test "round | rem :closest | explicit" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 5 / 3
-      expected = %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
-
-      assert Timecode.rem(a, b, round_remainder: :closest) == expected
-    end
-
-    test "round | rem :ceil" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 5 / 3
-      expected = %Timecode{seconds: Ratio.new(1, 24), rate: Rates.f24()}
-
-      assert Timecode.rem(a, b, round_remainder: :ceil) == expected
-    end
-
-    test "round | rem :floor" do
-      a = %Timecode{seconds: Ratio.new(47, 48), rate: Rates.f24()}
-      b = 5 / 3
-      expected = %Timecode{seconds: Ratio.new(0, 24), rate: Rates.f24()}
-
-      assert Timecode.rem(a, b, round_remainder: :floor) == expected
+    table_test "opts: | <%= opts %> <%= description %>", divrem_round_table, test_case do
+      %{a: a, b: b, opts: opts, expected_r: expected_remainder} = test_case
+      assert Timecode.rem(a, b, opts) == expected_remainder
     end
 
     test "round | frames :off | raises" do

--- a/test/timecode/timecode_parse_test.exs
+++ b/test/timecode/timecode_parse_test.exs
@@ -491,6 +491,25 @@ defmodule Vtc.TimecodeTest.Parse do
       |> check_parsed(test_case)
     end
 
+    round_sub_1_fps_table = [
+      %{input: Ratio.new(3, 1), expected: Ratio.new(3, 1)},
+      %{input: Ratio.new(-3, 1), expected: Ratio.new(-3, 1)},
+      %{input: Ratio.new(2, 1), expected: Ratio.new(3, 1)},
+      %{input: Ratio.new(-2, 1), expected: Ratio.new(-3, 1)},
+      %{input: Ratio.new(1, 1), expected: Ratio.new(0, 1)},
+      %{input: Ratio.new(-1, 1), expected: Ratio.new(0, 1)},
+      %{input: Ratio.new(0, 1), expected: Ratio.new(0, 1)}
+    ]
+
+    table_test "round | :closest | <%= input %> @ 1/3 fps -> <%= expected %>", round_sub_1_fps_table, test_case do
+      %{input: input, expected: expected} = test_case
+
+      rate = Framerate.new!(Ratio.new(1, 3), ntsc: nil)
+
+      assert {:ok, result} = Timecode.with_seconds(input, rate)
+      assert result.seconds == expected
+    end
+
     test "round | :closest | implied" do
       {:ok, result} = Timecode.with_seconds(Ratio.new(239, 240), Rates.f24())
       assert result == %Timecode{seconds: Ratio.new(1), rate: Rates.f24()}

--- a/test/timecode/timecode_property_test.exs
+++ b/test/timecode/timecode_property_test.exs
@@ -145,7 +145,7 @@ defmodule Vtc.TimecodeTest.Properties.ParseRoundTripDrop do
     end
   end
 
-  property "rounded seconds is valid with roudning off" do
+  property "rounded seconds successfully parsed by `with_seconds`, round: off" do
     check all(
             seconds <- StreamDataVtc.rational(),
             framerate <- StreamDataVtc.framerate()

--- a/test/timecode/timecode_property_test.exs
+++ b/test/timecode/timecode_property_test.exs
@@ -129,8 +129,8 @@ defmodule Vtc.TimecodeTest.Properties.ParseRoundTripDrop do
 
   property "timecode round trip" do
     check all(timecode <- StreamDataVtc.timecode(rate_opts: [type: [:whole, :non_drop, :drop]])) do
-      assert Timecode.with_seconds!(timecode.seconds, timecode.rate) == timecode
       timecode_str = Timecode.timecode(timecode)
+
       assert {:ok, result} = Timecode.with_frames(timecode_str, timecode.rate)
       assert result == timecode
     end
@@ -139,10 +139,19 @@ defmodule Vtc.TimecodeTest.Properties.ParseRoundTripDrop do
   property "59.94 frames round trip" do
     check all(frames <- StreamData.integer(-5_178_816..5_178_816)) do
       assert {:ok, timecode} = Timecode.with_frames(frames, Rates.f59_94_df())
-      assert Timecode.frames(timecode) == frames
+      Timecode.frames(timecode) == frames
 
-      timecode_str = Timecode.timecode(timecode)
-      assert {:ok, ^timecode} = Timecode.with_frames(timecode_str, Rates.f59_94_df()), "#{frames}"
+      assert {:ok, ^timecode} = Timecode.with_frames(frames, Rates.f59_94_df())
+    end
+  end
+
+  property "rounded seconds is valid with roudning off" do
+    check all(
+            seconds <- StreamDataVtc.rational(),
+            framerate <- StreamDataVtc.framerate()
+          ) do
+      assert {:ok, timecode} = Timecode.with_seconds(seconds, framerate)
+      assert {:ok, ^timecode} = Timecode.with_seconds(timecode.seconds, framerate, round: :off)
     end
   end
 end

--- a/test/timecode/timecode_property_test.exs
+++ b/test/timecode/timecode_property_test.exs
@@ -436,7 +436,7 @@ defmodule Vtc.TimecodeTest.Properties.Compare do
     end
   end
 
-  property "#lte?2 always matches compare/2" do
+  property "#lte?/2 always matches compare/2" do
     check all([a_frames, b_frames] <- list_of(integer(), length: 2)) do
       a = Timecode.with_frames!(a_frames, Rates.f23_98())
       b = Timecode.with_frames!(b_frames, Rates.f23_98())
@@ -445,7 +445,7 @@ defmodule Vtc.TimecodeTest.Properties.Compare do
     end
   end
 
-  property "#gt?2 always matches compare/2" do
+  property "#gt?/2 always matches compare/2" do
     check all([a_frames, b_frames] <- list_of(integer(), length: 2)) do
       a = Timecode.with_frames!(a_frames, Rates.f23_98())
       b = Timecode.with_frames!(b_frames, Rates.f23_98())
@@ -454,7 +454,7 @@ defmodule Vtc.TimecodeTest.Properties.Compare do
     end
   end
 
-  property "#gte?2 always matches frame comparson" do
+  property "#gte?/2 always matches frame comparson" do
     check all([a_frames, b_frames] <- list_of(integer(), length: 2)) do
       a = Timecode.with_frames!(a_frames, Rates.f23_98())
       b = Timecode.with_frames!(b_frames, Rates.f23_98())


### PR DESCRIPTION
- Adds core `PgTimecode.with_seconds/2` constructor, which is responsible for taking in a seconds value + a framerate and rounding `seconds` towards the nearest whole frame before constructing the composite. Mirrors `Timecode.with_seconds/3`.
- Adds out-of-the-box constraint generation for `PgTimecode` fields.
- Fixes bug when rounding seconds to the nearest whole frame when `rate` is less than one frame per second.