### PR TITLE
[Feature] PgFramestamp Comparison Operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install-dev:
 
 .PHONY: test
 test:
-	-mix test --exclude index_test --cover --warnings-as-errors
+	-mix test --cover --warnings-as-errors
 
 .PHONY: lint
 lint:

--- a/lib/ecto/postgres/pg_rational_migrations.ex
+++ b/lib/ecto/postgres/pg_rational_migrations.ex
@@ -17,8 +17,11 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   functions, casts, operators, and operator families.
 
   This migration included all migraitons under the
-  [PgTypes](Vtc.Ecto.Postgres.PgRational.Migrations.html#pgtypes) and
-  [PgFunctions](Vtc.Ecto.Postgres.PgRational.Migrations.html#pgfunctions)
+  [Pg Types](Vtc.Ecto.Postgres.PgRational.Migrations.html#pg-types),
+  [Pg Operators](Vtc.Ecto.Postgres.PgRational.Migrations.html#pg-operators),
+  [Pg Operator Classes](Vtc.Ecto.Postgres.PgRational.Migrations.html#pg-operator-classes),
+  [Pg Functions](Vtc.Ecto.Postgres.PgRational.Migrations.html#pg-functions), and
+  [Pg Private Functions](Vtc.Ecto.Postgres.PgRational.Migrations.html#pg-private-functions),
   headings.
 
   Safe to run multiple times when new functionality is added in updates to this library.
@@ -206,7 +209,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     :ok
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates `rational_private.greatest_common_denominator(a, b)` function that finds the
   greatest common denominator between two bigint values.
@@ -235,7 +238,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates `rational_private.simplify(rat)` function that simplifies a rational. Used at
   the end of every rational operation to avoid overflows.
@@ -340,7 +343,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates a native CAST from `rational` to `double precision`.
   """
@@ -361,7 +364,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   ## ARITHMATIC BACKING FUNCS
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates `rational_private.add(a, b)` backing function for the `+` operator
   between two rationals.
@@ -386,7 +389,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.sub(a, b)` backing function for the `-` operator
   between two rationals.
@@ -411,7 +414,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.mult(a, b)` backing function for the `*` operator
   between two rationals.
@@ -436,7 +439,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.div(a, b)` backing function for the `/` operator
   between two rationals.
@@ -461,7 +464,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.modulo(a, b)` backing function for the `%` operator
   between two rationals.
@@ -492,7 +495,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
 
   ## COMPARISON BACKING FUNCS
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.cmp(a, b)` that returns:
 
@@ -530,7 +533,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.eq(a, b)` that backs the `=` operator.
   """
@@ -549,7 +552,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.eq(a, b)` that backs the `=` operator.
   """
@@ -568,7 +571,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.eq(a, b)` that backs the `=` operator.
   """
@@ -587,7 +590,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.eq(a, b)` that backs the `=` operator.
   """
@@ -611,7 +614,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.eq(a, b)` that backs the `=` operator.
   """
@@ -630,7 +633,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     Migration.execute(create_func)
   end
 
-  @doc section: :migrations_functions
+  @doc section: :migrations_private_functions
   @doc """
   Creates Creates `rational_private.eq(a, b)` that backs the `=` operator.
   """
@@ -879,6 +882,11 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   end
 
   ## OPERATOR CLASSES
+
+  @doc section: :migrations_operator_classes
+  @doc """
+  Creates a B-tree operator class to support indexing on comparison operations.
+  """
   @spec create_op_class_btree() :: :ok
   def create_op_class_btree do
     create_class =
@@ -970,8 +978,10 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
     "#{function_prefix}#{name}"
   end
 
+  # Returns the config-qualified name of the function for this type.
+  @doc false
   @spec private_function(atom(), Ecto.Repo.t()) :: String.t()
-  defp private_function(name, repo) do
+  def private_function(name, repo) do
     function_prefix = Postgres.Utils.type_private_function_prefix(repo, :pg_rational)
     "#{function_prefix}#{name}"
   end

--- a/mix.exs
+++ b/mix.exs
@@ -52,11 +52,13 @@ defmodule Vtc.MixProject do
           Perfs: &(&1[:section] == :perfs),
           Queries: &(&1[:section] == :ecto_queries),
           Full: &(&1[:section] == :migrations_full),
-          PgConstraints: &(&1[:section] == :migrations_constraints),
-          PgTypes: &(&1[:section] == :migrations_types),
-          PgCasts: &(&1[:section] == :migrations_casts),
-          PgOperators: &(&1[:section] == :migrations_operators),
-          PgFunctions: &(&1[:section] == :migrations_functions)
+          "Pg Constraints": &(&1[:section] == :migrations_constraints),
+          "Pg Types": &(&1[:section] == :migrations_types),
+          "Pg Casts": &(&1[:section] == :migrations_casts),
+          "Pg Operators": &(&1[:section] == :migrations_operators),
+          "Pg Operator Classes": &(&1[:section] == :migrations_operator_classes),
+          "Pg Functions": &(&1[:section] == :migrations_functions),
+          "Pg Private Functions": &(&1[:section] == :migrations_private_functions)
         ]
       ],
       build_embedded: Mix.env() == :prod,

--- a/priv/repo/migrations/20230626000041_add_framestamp_schemas.exs
+++ b/priv/repo/migrations/20230626000041_add_framestamp_schemas.exs
@@ -13,5 +13,7 @@ defmodule Vtc.Test.Support.Repo.Migrations.AddTimecodeSchemas do
     end
 
     :ok = PgFramestamp.Migrations.create_field_constraints("framestamps_01", :b)
+
+    create(index("framestamps_01", [:b]))
   end
 end

--- a/test/ecto/postgres/pg_index_test.exs
+++ b/test/ecto/postgres/pg_index_test.exs
@@ -13,8 +13,12 @@ defmodule Vtc.Ecto.Postgres.PgRationalIndexTest do
 
   use Vtc.Test.Support.EctoCase, async: false
 
+  alias Ecto.Changeset
   alias Ecto.Query
   alias Vtc.Ecto.Postgres.PgRational
+  alias Vtc.Framestamp
+  alias Vtc.Rates
+  alias Vtc.Test.Support.FramestampSchema01
   alias Vtc.Test.Support.RationalsSchema02
 
   require Ecto.Query
@@ -23,17 +27,20 @@ defmodule Vtc.Ecto.Postgres.PgRationalIndexTest do
 
   describe "PgRational" do
     test "BTREE indexing" do
-      assert {:ok, %{id: _}} =
-               %RationalsSchema02{}
-               |> RationalsSchema02.changeset(%{a: Ratio.new(1, 2), b: Ratio.new(1, 4)})
-               |> Repo.insert()
+      inserted =
+        1..20_000
+        |> Enum.map(fn denominator ->
+          RationalsSchema02.changeset(%RationalsSchema02{}, %{
+            id: Ecto.UUID.generate(),
+            a: Ratio.new(1, 2),
+            b: Ratio.new(1, denominator)
+          })
+        end)
+        |> Enum.map(&Changeset.apply_action!(&1, :insert))
+        |> Enum.map(&Map.take(&1, [:id, :a, :b]))
+        |> then(&Repo.insert_all(RationalsSchema02, &1))
 
-      for denominator <- 1..20_000 do
-        assert {:ok, _} =
-                 %RationalsSchema02{}
-                 |> RationalsSchema02.changeset(%{a: Ratio.new(1, 2), b: Ratio.new(1, denominator)})
-                 |> Repo.insert()
-      end
+      assert inserted == {20_000, nil}
 
       value = Ratio.new(1, 10_000)
       expected_plan_snippet = "Index Scan using rationals_02_b_index on rationals_02 r0"
@@ -43,7 +50,6 @@ defmodule Vtc.Ecto.Postgres.PgRationalIndexTest do
         |> Query.select([r], r.id)
         |> Query.where([r], r.b < type(^value, PgRational))
         |> then(&Repo.explain(:all, &1))
-        |> dbg()
 
       assert lt_plan =~ expected_plan_snippet
 
@@ -52,7 +58,6 @@ defmodule Vtc.Ecto.Postgres.PgRationalIndexTest do
         |> Query.select([r], r.id)
         |> Query.where([r], r.b <= type(^value, PgRational))
         |> then(&Repo.explain(:all, &1))
-        |> dbg()
 
       assert lte_plan =~ expected_plan_snippet
 
@@ -61,7 +66,6 @@ defmodule Vtc.Ecto.Postgres.PgRationalIndexTest do
         |> Query.select([r], r.id)
         |> Query.where([r], r.b == type(^value, PgRational))
         |> then(&Repo.explain(:all, &1))
-        |> dbg()
 
       assert eq_plan =~ expected_plan_snippet
 
@@ -70,7 +74,6 @@ defmodule Vtc.Ecto.Postgres.PgRationalIndexTest do
         |> Query.select([r], r.id)
         |> Query.where([r], r.b > type(^value, PgRational))
         |> then(&Repo.explain(:all, &1))
-        |> dbg()
 
       assert gt_plan =~ expected_plan_snippet
 
@@ -79,7 +82,68 @@ defmodule Vtc.Ecto.Postgres.PgRationalIndexTest do
         |> Query.select([r], r.id)
         |> Query.where([r], r.b >= type(^value, PgRational))
         |> then(&Repo.explain(:all, &1))
-        |> dbg()
+
+      assert gte_plan =~ expected_plan_snippet
+    end
+  end
+
+  describe "PgFramestamp" do
+    test "BTREE indexing" do
+      inserted =
+        1..20_000
+        |> Enum.map(fn frames ->
+          FramestampSchema01.changeset(%FramestampSchema01{}, %{
+            id: Ecto.UUID.generate(),
+            a: Framestamp.with_frames!(12, Rates.f24()),
+            b: Framestamp.with_frames!(frames, Rates.f24())
+          })
+        end)
+        |> Enum.map(&Changeset.apply_action!(&1, :insert))
+        |> Enum.map(&Map.take(&1, [:id, :a, :b]))
+        |> then(&Repo.insert_all(FramestampSchema01, &1))
+
+      assert inserted == {20_000, nil}
+
+      value = Framestamp.with_frames!(1, Rates.f24())
+      expected_plan_snippet = "Index Scan using framestamps_01_b_index on framestamps_01 f0"
+
+      lt_plan =
+        FramestampSchema01
+        |> Query.select([r], r.id)
+        |> Query.where([r], r.b < type(^value, Framestamp))
+        |> then(&Repo.explain(:all, &1))
+
+      assert lt_plan =~ expected_plan_snippet
+
+      lte_plan =
+        FramestampSchema01
+        |> Query.select([r], r.id)
+        |> Query.where([r], r.b <= type(^value, Framestamp))
+        |> then(&Repo.explain(:all, &1))
+
+      assert lte_plan =~ expected_plan_snippet
+
+      eq_plan =
+        FramestampSchema01
+        |> Query.select([r], r.id)
+        |> Query.where([r], r.b == type(^value, Framestamp))
+        |> then(&Repo.explain(:all, &1))
+
+      assert eq_plan =~ expected_plan_snippet
+
+      gt_plan =
+        FramestampSchema01
+        |> Query.select([r], r.id)
+        |> Query.where([r], r.b > type(^value, Framestamp))
+        |> then(&Repo.explain(:all, &1))
+
+      assert gt_plan =~ expected_plan_snippet
+
+      gte_plan =
+        FramestampSchema01
+        |> Query.select([r], r.id)
+        |> Query.where([r], r.b >= type(^value, Framestamp))
+        |> then(&Repo.explain(:all, &1))
 
       assert gte_plan =~ expected_plan_snippet
     end

--- a/test/framestamp/framestamp_ops_test.exs
+++ b/test/framestamp/framestamp_ops_test.exs
@@ -4,6 +4,7 @@ defmodule Vtc.FramestampTest.Ops do
 
   alias Vtc.Framestamp
   alias Vtc.Rates
+  alias Vtc.Test.Support.CommonTables
 
   rebase_table = [
     %{
@@ -34,8 +35,8 @@ defmodule Vtc.FramestampTest.Ops do
   ]
 
   describe "#rebase/2" do
-    setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:original, :expected]
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:original, :expected]
 
     table_test "<%= original %> -> <%= new_rate %>", rebase_table, test_case do
       %{original: original, new_rate: new_rate, expected: expected} = test_case
@@ -48,8 +49,8 @@ defmodule Vtc.FramestampTest.Ops do
   end
 
   describe "#rebase!/2" do
-    setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:original, :expected]
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:original, :expected]
 
     table_test "<%= original %> -> <%= new_rate %>", rebase_table, test_case do
       %{original: original, new_rate: new_rate, expected: expected} = test_case
@@ -62,75 +63,17 @@ defmodule Vtc.FramestampTest.Ops do
   end
 
   describe "#compare/2" do
-    setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:a, :b]
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:a, :b]
 
-    compare_table = [
-      %{
-        a: "01:00:00:00",
-        b: "01:00:00:00",
-        expected: :eq
-      },
-      %{
-        a: "00:00:00:00",
-        b: "01:00:00:00",
-        expected: :lt
-      },
-      %{
-        a: "-01:00:00:00",
-        b: "01:00:00:00",
-        expected: :lt
-      },
-      %{
-        a: "02:00:00:00",
-        b: "01:00:00:00",
-        expected: :gt
-      },
-      %{
-        a: "02:00:00:00",
-        b: "00:00:00:00",
-        expected: :gt
-      },
-      %{
-        a: "02:00:00:00",
-        b: "-01:00:00:00",
-        expected: :gt
-      },
-      %{
-        a: "00:00:59:23",
-        b: "01:00:00:00",
-        expected: :lt
-      },
-      %{
-        a: "01:00:00:01",
-        b: "01:00:00:00",
-        expected: :gt
-      },
-      %{
-        a: {"01:00:00:00", Rates.f23_98()},
-        b: {"01:00:00:00", Rates.f24()},
-        expected: :gt
-      },
-      %{
-        a: {"01:00:00:00", Rates.f23_98()},
-        b: {"01:00:00:00", Rates.f59_94_ndf()},
-        expected: :eq
-      },
-      %{
-        a: {"01:00:00:00", Rates.f59_94_df()},
-        b: {"01:00:00:00", Rates.f59_94_ndf()},
-        expected: :lt
-      }
-    ]
-
-    table_test "<%= a %> is <%= expected %> <%= b %>", compare_table, test_case do
+    table_test "<%= a %> is <%= expected %> <%= b %>", CommonTables.compare_table(), test_case do
       %{a: a, b: b, expected: expected} = test_case
       assert Framestamp.compare(a, b) == expected
     end
 
     name = "<%= a %> is <%= expected %> <%= b %> | b = tc string"
 
-    table_test name, compare_table, test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
+    table_test name, CommonTables.compare_table(), test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       b = Framestamp.smpte_timecode(b)
 
@@ -139,7 +82,7 @@ defmodule Vtc.FramestampTest.Ops do
 
     name = "<%= a %> is <%= expected %> <%= b %> | a = tc string"
 
-    table_test name, compare_table, test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
+    table_test name, CommonTables.compare_table(), test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       a = Framestamp.smpte_timecode(a)
 
@@ -148,7 +91,7 @@ defmodule Vtc.FramestampTest.Ops do
 
     name = "<%= a %> is <%= expected %> <%= b %> | b = frames int"
 
-    table_test name, compare_table, test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
+    table_test name, CommonTables.compare_table(), test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       b = Framestamp.frames(b)
 
@@ -157,7 +100,7 @@ defmodule Vtc.FramestampTest.Ops do
 
     name = "<%= a %> is <%= expected %> <%= b %> | a = frames int"
 
-    table_test name, compare_table, test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
+    table_test name, CommonTables.compare_table(), test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       a = Framestamp.frames(a)
 
@@ -166,6 +109,9 @@ defmodule Vtc.FramestampTest.Ops do
   end
 
   describe "#eq?/2" do
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:a, :b]
+
     test "true" do
       a = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
       b = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
@@ -179,9 +125,19 @@ defmodule Vtc.FramestampTest.Ops do
 
       refute Framestamp.eq?(a, b)
     end
+
+    table_test "<%= a %>, <%= b %>", CommonTables.compare_table(), test_case do
+      %{a: a, b: b, expected: cmp_expected} = test_case
+      expected = cmp_expected == :eq
+
+      assert Framestamp.eq?(a, b) == expected
+    end
   end
 
   describe "#lt?/2" do
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:a, :b]
+
     test "true" do
       a = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
       b = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
@@ -202,9 +158,19 @@ defmodule Vtc.FramestampTest.Ops do
 
       refute Framestamp.lt?(a, b)
     end
+
+    table_test "<%= a %>, <%= b %>", CommonTables.compare_table(), test_case do
+      %{a: a, b: b, expected: cmp_expected} = test_case
+      expected = cmp_expected == :lt
+
+      assert Framestamp.lt?(a, b) == expected
+    end
   end
 
   describe "#lte?/2" do
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:a, :b]
+
     test "true" do
       a = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
       b = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
@@ -225,9 +191,19 @@ defmodule Vtc.FramestampTest.Ops do
 
       refute Framestamp.lte?(a, b)
     end
+
+    table_test "<%= a %>, <%= b %>", CommonTables.compare_table(), test_case do
+      %{a: a, b: b, expected: cmp_expected} = test_case
+      expected = cmp_expected in [:lt, :eq]
+
+      assert Framestamp.lte?(a, b) == expected
+    end
   end
 
   describe "#gt?/2" do
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:a, :b]
+
     test "true" do
       a = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
       b = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
@@ -248,9 +224,19 @@ defmodule Vtc.FramestampTest.Ops do
 
       refute Framestamp.gt?(a, b)
     end
+
+    table_test "<%= a %>, <%= b %>", CommonTables.compare_table(), test_case do
+      %{a: a, b: b, expected: cmp_expected} = test_case
+      expected = cmp_expected == :gt
+
+      assert Framestamp.gt?(a, b) == expected
+    end
   end
 
   describe "#gte?/2" do
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:a, :b]
+
     test "true" do
       a = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
       b = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
@@ -271,11 +257,18 @@ defmodule Vtc.FramestampTest.Ops do
 
       refute Framestamp.gte?(a, b)
     end
+
+    table_test "<%= a %>, <%= b %>", CommonTables.compare_table(), test_case do
+      %{a: a, b: b, expected: cmp_expected} = test_case
+      expected = cmp_expected in [:gt, :eq]
+
+      assert Framestamp.gte?(a, b) == expected
+    end
   end
 
   describe "#add/2" do
-    setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:a, :b, :expected]
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:a, :b, :expected]
 
     add_table = [
       %{
@@ -468,8 +461,8 @@ defmodule Vtc.FramestampTest.Ops do
   end
 
   describe "#sub/2" do
-    setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:a, :b, :expected]
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:a, :b, :expected]
 
     sub_table = [
       %{
@@ -662,8 +655,8 @@ defmodule Vtc.FramestampTest.Ops do
   end
 
   describe "#mult/2" do
-    setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:a, :expected]
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:a, :expected]
 
     mult_table = [
       %{
@@ -800,8 +793,8 @@ defmodule Vtc.FramestampTest.Ops do
   end
 
   describe "#div/2" do
-    setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:a, :expected]
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:a, :expected]
 
     div_table = [
       %{
@@ -1181,8 +1174,8 @@ defmodule Vtc.FramestampTest.Ops do
   ]
 
   describe "#divrem/2" do
-    setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:dividend, :expected_q, :expected_r]
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:dividend, :expected_q, :expected_r]
 
     table_test "<%= dividend %> /% <%= divisor %> == <%= expected_q %>, <%= expected_r %>", divrem_table, test_case do
       %{dividend: dividend, divisor: divisor, expected_q: expected_quotient, expected_r: expected_remainder} = test_case
@@ -1218,8 +1211,8 @@ defmodule Vtc.FramestampTest.Ops do
   end
 
   describe "#rem/2" do
-    setup context, do: TestCase.setup_timecodes(context)
-    @describetag timecodes: [:dividend, :expected_q, :expected_r]
+    setup context, do: TestCase.setup_framestamps(context)
+    @describetag framestamps: [:dividend, :expected_q, :expected_r]
 
     table_test "<%= dividend %> % <%= divisor %> == <%= expected_r %>", divrem_table, test_case do
       %{dividend: dividend, divisor: divisor, expected_r: expected} = test_case

--- a/test/range_test.exs
+++ b/test/range_test.exs
@@ -483,11 +483,11 @@ defmodule Vtc.RangeTest do
   end
 
   describe "#contains/2?" do
-    setup context, do: TestCase.setup_timecodes(context)
+    setup context, do: TestCase.setup_framestamps(context)
     setup [:setup_ranges]
     setup context, do: TestCase.setup_negates(context)
 
-    @describetag timecodes: [:framestamp]
+    @describetag framestamps: [:framestamp]
     @describetag ranges: [:range]
 
     contains_table = [

--- a/test/support/common_tables.ex
+++ b/test/support/common_tables.ex
@@ -1,0 +1,145 @@
+defmodule Vtc.Test.Support.CommonTables do
+  @moduledoc false
+  alias Vtc.Rates
+  alias Vtc.Test.Support.TestCase
+
+  @doc """
+  Data for running tests on comparison operators.
+  """
+  @spec compare_table() ::
+          [%{a: TestCase.framestamp_input(), b: TestCase.framestamp_input(), expected: :eq | :lt | :gt}]
+  def compare_table do
+    [
+      %{
+        a: "01:00:00:00",
+        b: "01:00:00:00",
+        expected: :eq
+      },
+      %{
+        a: "-01:00:00:00",
+        b: "01:00:00:00",
+        expected: :lt
+      },
+      %{
+        a: "01:00:00:00",
+        b: "-01:00:00:00",
+        expected: :gt
+      },
+      %{
+        a: "-01:00:00:00",
+        b: "-01:00:00:00",
+        expected: :eq
+      },
+      %{
+        a: "00:00:00:00",
+        b: "01:00:00:00",
+        expected: :lt
+      },
+      %{
+        a: "00:00:00:00",
+        b: "-01:00:00:00",
+        expected: :gt
+      },
+      %{
+        a: "02:00:00:00",
+        b: "01:00:00:00",
+        expected: :gt
+      },
+      %{
+        a: "-02:00:00:00",
+        b: "01:00:00:00",
+        expected: :lt
+      },
+      %{
+        a: "02:00:00:00",
+        b: "-01:00:00:00",
+        expected: :gt
+      },
+      %{
+        a: "-02:00:00:00",
+        b: "-01:00:00:00",
+        expected: :lt
+      },
+      %{
+        a: "02:00:00:00",
+        b: "00:00:00:00",
+        expected: :gt
+      },
+      %{
+        a: "-02:00:00:00",
+        b: "00:00:00:00",
+        expected: :lt
+      },
+      %{
+        a: "00:00:59:23",
+        b: "01:00:00:00",
+        expected: :lt
+      },
+      %{
+        a: "01:00:00:01",
+        b: "01:00:00:00",
+        expected: :gt
+      },
+      %{
+        a: {"01:00:00:00", Rates.f23_98()},
+        b: {"01:00:00:00", Rates.f24()},
+        expected: :gt
+      },
+      %{
+        a: {"-01:00:00:00", Rates.f23_98()},
+        b: {"01:00:00:00", Rates.f24()},
+        expected: :lt
+      },
+      %{
+        a: {"01:00:00:00", Rates.f23_98()},
+        b: {"-01:00:00:00", Rates.f24()},
+        expected: :gt
+      },
+      %{
+        a: {"-01:00:00:00", Rates.f23_98()},
+        b: {"-01:00:00:00", Rates.f24()},
+        expected: :lt
+      },
+      %{
+        a: {"01:00:00:00", Rates.f23_98()},
+        b: {"01:00:00:00", Rates.f59_94_ndf()},
+        expected: :eq
+      },
+      %{
+        a: {"-01:00:00:00", Rates.f23_98()},
+        b: {"01:00:00:00", Rates.f59_94_ndf()},
+        expected: :lt
+      },
+      %{
+        a: {"01:00:00:00", Rates.f23_98()},
+        b: {"-01:00:00:00", Rates.f59_94_ndf()},
+        expected: :gt
+      },
+      %{
+        a: {"-01:00:00:00", Rates.f23_98()},
+        b: {"-01:00:00:00", Rates.f59_94_ndf()},
+        expected: :eq
+      },
+      %{
+        a: {"01:00:00:00", Rates.f59_94_df()},
+        b: {"01:00:00:00", Rates.f59_94_ndf()},
+        expected: :lt
+      },
+      %{
+        a: {"-01:00:00:00", Rates.f59_94_df()},
+        b: {"01:00:00:00", Rates.f59_94_ndf()},
+        expected: :lt
+      },
+      %{
+        a: {"01:00:00:00", Rates.f59_94_df()},
+        b: {"-01:00:00:00", Rates.f59_94_ndf()},
+        expected: :gt
+      },
+      %{
+        a: {"-01:00:00:00", Rates.f59_94_df()},
+        b: {"-01:00:00:00", Rates.f59_94_ndf()},
+        expected: :gt
+      }
+    ]
+  end
+end

--- a/test/support/framestamp_schema_01.ex
+++ b/test/support/framestamp_schema_01.ex
@@ -21,5 +21,5 @@ defmodule Vtc.Test.Support.FramestampSchema01 do
   end
 
   @spec changeset(%__MODULE__{}, %{atom() => any()}) :: Changeset.t(%__MODULE__{})
-  def changeset(schema, attrs), do: Changeset.cast(schema, attrs, [:a, :b])
+  def changeset(schema, attrs), do: Changeset.cast(schema, attrs, [:id, :a, :b])
 end

--- a/test/support/rational_schema_02.ex
+++ b/test/support/rational_schema_02.ex
@@ -23,7 +23,7 @@ defmodule Vtc.Test.Support.RationalsSchema02 do
   @spec changeset(%__MODULE__{}, %{atom() => any()}) :: Changeset.t()
   def changeset(schema, attrs) do
     schema
-    |> Changeset.cast(attrs, [:a, :b])
+    |> Changeset.cast(attrs, [:id, :a, :b])
     |> Changeset.validate_required([:a, :b])
   end
 end

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -42,21 +42,26 @@ defmodule Vtc.Test.Support.TestCase do
   def setup_test_case(context), do: context
 
   @doc """
-  Sets up timecodes found in any context fields listed in the `:timecodes` context
+  Sets up timecodes found in any context fields listed in the `:framestamps` context
   field.
   """
-  @spec setup_timecodes(map()) :: Keyword.t()
-  def setup_timecodes(context) do
-    timecode_fields = Map.get(context, :timecodes, [])
+  @spec setup_framestamps(map()) :: Keyword.t()
+  def setup_framestamps(context) do
+    timecode_fields = Map.get(context, :framestamps, [])
     timecodes = Map.take(context, timecode_fields)
 
-    Enum.map(timecodes, fn {field_name, value} -> {field_name, setup_timecode(value)} end)
+    Enum.map(timecodes, fn {field_name, value} -> {field_name, setup_framestamp(value)} end)
   end
 
-  @spec setup_timecode(Framestamp.t() | Frames.t() | {Frames.t(), Framerate.t()}) :: Framestamp.t()
-  defp setup_timecode(%Framestamp{} = value), do: value
-  defp setup_timecode({frames, rate}), do: Framestamp.with_frames!(frames, rate)
-  defp setup_timecode(frames), do: setup_timecode({frames, Rates.f23_98()})
+  @typedoc """
+  The ExUnit test context values that can be loaded into framestamps from timecodes.
+  """
+  @type framestamp_input() :: Framestamp.t() | Frames.t() | {Frames.t(), Framerate.t()}
+
+  @spec setup_framestamp(framestamp_input()) :: Framestamp.t()
+  defp setup_framestamp(%Framestamp{} = value), do: value
+  defp setup_framestamp({frames, rate}), do: Framestamp.with_frames!(frames, rate)
+  defp setup_framestamp(frames), do: setup_framestamp({frames, Rates.f23_98()})
 
   @doc """
   Mathematically negates a list of keys in the context.


### PR DESCRIPTION
Adds native comparison operators and Btree operator class to the `framestamp` postgres type. Allows use of native functions and ORDER BY:

```elixir
      record_01_start = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
      record_02_start = Framestamp.with_frames!("01:00:00:01", Rates.f23_98())
      record_03_start = Framestamp.with_frames!("00:59:59:23", Rates.f23_98())

      record_01 = %FramestampSchema01{} |> FramestampSchema01.changeset(%{a: record_01_start}) |> Repo.insert!()
      record_02 = %FramestampSchema01{} |> FramestampSchema01.changeset(%{a: record_02_start}) |> Repo.insert!()
      record_03 = %FramestampSchema01{} |> FramestampSchema01.changeset(%{a: record_03_start}) |> Repo.insert!()

      records =
        FramestampSchema01
        |> Query.from(order_by: :a)
        |> Repo.all()

      assert is_list(records)
      assert length(records) == 3

      returned_ids = Enum.map(records, & &1.id)
      expected_ids = [record_03.id, record_01.id, record_02.id]

      assert returned_ids == expected_ids
```