### PR TITLE
[Refactor] Rename `Vtc.Range` to `Vtc.Framestamp.Range`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,17 @@ iex> end
 "<19:08:13:02 <23.98 NTSC>>"
 ```
 
-[Ranges](`Vtc.Range`) let you operate on in/out points, for instance, finding the 
+[Ranges](`Vtc.Framestamp.Range`) let you operate on in/out points, for instance, finding the 
 overlapping area between two ranges:
 
 ```elixir
 iex> a_in = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
-iex> a = Range.new!(a_in, "02:00:00:00")
+iex> a = Framestamp.Range.new!(a_in, "02:00:00:00")
 "<01:00:00:00 - 02:00:00:00 :exclusive <23.98 NTSC>>"
 iex> b_in = Framestamp.with_frames!("01:45:00:00", Rates.f23_98())
-iex> b = Range.new!(b_in, "02:30:00:00")
+iex> b = Framestamp.Range.new!(b_in, "02:30:00:00")
 "<01:45:00:00 - 02:30:00:00 :exclusive <23.98 NTSC>>"
-iex> Range.intersection!(a, b)
+iex> Framestamp.Range.intersection!(a, b)
 "<01:45:00:00 - 02:00:00:00 :exclusive <23.98 NTSC>>"
 ```
 

--- a/lib/framestamp_range.ex
+++ b/lib/framestamp_range.ex
@@ -1,4 +1,4 @@
-defmodule Vtc.Range do
+defmodule Vtc.Framestamp.Range do
   @moduledoc """
   Holds a framestamp range.
 
@@ -44,7 +44,7 @@ defmodule Vtc.Range do
 
   @doc section: :parse
   @doc """
-  Creates a new [Range](`Vtc.Range`).
+  Creates a new [Range](`Vtc.Framestamp.Range`).
 
   `out_tc` may be a [Framestamp](`Vtc.Framestamp`) value for any value that implements the
   [Frames](`Vtc.Source.Frames`) protocol.
@@ -563,9 +563,9 @@ defmodule Vtc.Range do
   end
 end
 
-defimpl Inspect, for: Vtc.Range do
+defimpl Inspect, for: Vtc.Framestamp.Range do
   alias Vtc.Framestamp
-  alias Vtc.Range
+  alias Vtc.Framestamp.Range
 
   @spec inspect(Range.t(), Elixir.Inspect.Opts.t()) :: String.t()
   def inspect(range, _opts) do
@@ -573,8 +573,8 @@ defimpl Inspect, for: Vtc.Range do
   end
 end
 
-defimpl String.Chars, for: Vtc.Range do
-  alias Vtc.Range
+defimpl String.Chars, for: Vtc.Framestamp.Range do
+  alias Vtc.Framestamp.Range
 
   @spec to_string(Range.t()) :: String.t()
   def to_string(range), do: inspect(range)

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Vtc.MixProject do
           "CONTRIBUTING.md"
         ],
         groups_for_modules: [
-          "Core API": [Vtc.Framestamp, Vtc.Framerate, Vtc.Range],
+          "Core API": [Vtc.Framestamp, Vtc.Framerate, Vtc.Framestamp.Range],
           Data: [Vtc.SMPTETimecode.Sections, Vtc.Rates, Vtc.FilmFormat],
           "Frames Formats": [Frames.FeetAndFrames, Frames.SMPTETimecodeStr],
           "Seconds Formats": [Seconds.PremiereTicks, Seconds.RuntimeStr],

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [version]
-target = 0.12
+target = 0.13
 release =
 
 [testing]

--- a/test/docstrings_test.exs
+++ b/test/docstrings_test.exs
@@ -5,7 +5,7 @@ defmodule Vtc.DocsTest do
 
   alias Vtc.Framerate
   alias Vtc.Framestamp
-  alias Vtc.Range
+  alias Vtc.Framestamp.Range
   alias Vtc.Rates
   alias Vtc.Source
 

--- a/test/range_test.exs
+++ b/test/range_test.exs
@@ -1,10 +1,10 @@
-defmodule Vtc.RangeTest do
+defmodule Vtc.Framestamp.RangeTest do
   @moduledoc false
   use Vtc.Test.Support.TestCase
 
   alias Vtc.Framerate
   alias Vtc.Framestamp
-  alias Vtc.Range
+  alias Vtc.Framestamp.Range
   alias Vtc.Rates
 
   @typedoc """

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -2,7 +2,7 @@ defmodule Vtc.Test.Support.TestCase do
   @moduledoc false
   alias Vtc.Framerate
   alias Vtc.Framestamp
-  alias Vtc.Range
+  alias Vtc.Framestamp.Range
   alias Vtc.Rates
   alias Vtc.Source.Frames
   alias Vtc.Source.Frames.FeetAndFrames

--- a/zdocs/quickstart.cheatmd
+++ b/zdocs/quickstart.cheatmd
@@ -382,10 +382,10 @@ iex> Enum.sort_by([data_02, data_01], & &1.tc, Framestamp)
 
 ## Ranges
 
-[Range](`Vtc.Range`) helps with common operations using in/out points. Let's set two of 
+[Range](`Vtc.Framestamp.Range`) helps with common operations using in/out points. Let's set two of 
 those up.
 
-#### [new/3](`Vtc.Range.new/3`)
+#### [new/3](`Vtc.Framestamp.Range.new/3`)
 
 ```elixir
 iex> a_in = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
@@ -402,7 +402,7 @@ inclusive out points like you are used to are available as well!
 
 Just like addition, we can write a bare timecode string as the out value if we want.
 
-#### [new/3](`Vtc.Range.new/3`) with string
+#### [new/3](`Vtc.Framestamp.Range.new/3`) with string
 
 ```elixir
 iex> b_in = Framestamp.with_frames!("01:45:00:00", Rates.f23_98())
@@ -413,7 +413,7 @@ iex> b = Range.new!(b_in, "02:30:00:00")
 
 We can get the duration of a range.
 
-#### [duration/1](`Vtc.Range.duration/1`)
+#### [duration/1](`Vtc.Framestamp.Range.duration/1`)
 
 ```elixir
 iex> Range.duration(b)
@@ -422,7 +422,7 @@ iex> "<00:45:00:00 <23.98 NTSC>>"
 
 ... see if a specific framestamp is in a range:
 
-#### [contains?/2](`Vtc.Range.contains?/2`)
+#### [contains?/2](`Vtc.Framestamp.Range.contains?/2`)
 
 ```elixir
 iex> Range.contains?(b, "02:00:00:00")
@@ -431,7 +431,7 @@ iex> true
 
 ... or see if it overlaps with another range.
 
-#### [overlaps?/2](`Vtc.Range.overlaps?/2`)
+#### [overlaps?/2](`Vtc.Framestamp.Range.overlaps?/2`)
 
 ```elixir
 iex> Range.overlaps?(a, b)
@@ -440,7 +440,7 @@ iex> true
 
 We can even get the overlapping area as its own range!
 
-#### [intersection/2](`Vtc.Range.intersection/2`)
+#### [intersection/2](`Vtc.Framestamp.Range.intersection/2`)
 
 ```elixir
 iex> Range.intersection!(a, b)


### PR DESCRIPTION
Makes calling code more precise when dealing with framestamp ranges.