### PR TITLE
[Feature] Add strict equality checks to PgFramerate

### DIFF
--- a/lib/ecto/postgres/pg_framerate_migrations.ex
+++ b/lib/ecto/postgres/pg_framerate_migrations.ex
@@ -211,11 +211,9 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
         args: [a: :framerate, b: :framerate],
         returns: :boolean,
         body: """
-        RETURN (
-          (a).playback = (b).playback
+        RETURN (a).playback = (b).playback
           AND (a).tags <@ (b).tags
-          AND (a).tags @> (b).tags
-        );
+          AND (a).tags @> (b).tags;
         """
       )
 
@@ -234,11 +232,9 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
         args: [a: :framerate, b: :framerate],
         returns: :boolean,
         body: """
-        RETURN (
-          (a).playback != (b).playback
+        RETURN (a).playback != (b).playback
           OR NOT (a).tags <@ (b).tags
-          OR NOT (a).tags @> (b).tags
-        );
+          OR NOT (a).tags @> (b).tags;
         """
       )
 

--- a/lib/ecto/postgres/pg_framerate_migrations.ex
+++ b/lib/ecto/postgres/pg_framerate_migrations.ex
@@ -7,6 +7,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   """
   alias Ecto.Migration
   alias Vtc.Ecto.Postgres
+  alias Vtc.Ecto.Postgres.PgRational
 
   require Ecto.Migration
 
@@ -361,6 +362,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
 
     Migration.create(ntsc_tags)
 
+    rational_round = PgRational.Migrations.function(:round, Migration.repo())
+
     ntsc_valid =
       Migration.constraint(
         table,
@@ -369,7 +372,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
         NOT #{function(:is_ntsc, Migration.repo())}(#{target_value})
         OR (
             (
-              round((#{target_value}).playback.numerator::float / (#{target_value}).playback.denominator::float) * 1000,
+              #{rational_round}((#{target_value}).playback) * 1000,
               1001
             )::rational
             = (#{target_value}).playback

--- a/lib/ecto/postgres/pg_framestamp_migrations.ex
+++ b/lib/ecto/postgres/pg_framestamp_migrations.ex
@@ -182,7 +182,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
         declares: [rounded: :bigint],
         returns: :framestamp,
         body: """
-        SELECT #{rational_round}((rate).playback * seconds) INTO rounded;
+        rounded := #{rational_round}((rate).playback * seconds);
         RETURN (((rounded, 1)::rational / (rate).playback), rate);
         """
       )

--- a/lib/ecto/postgres/pg_framestamp_migrations.ex
+++ b/lib/ecto/postgres/pg_framestamp_migrations.ex
@@ -224,9 +224,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
         returns: :boolean,
         body: """
         RETURN (a).seconds = (b.seconds)
-          AND (a).rate.playback = (b).rate.playback
-          AND (a).rate.tags <@ (b).rate.tags
-          AND (a).rate.tags @> (b).rate.tags;
+          AND (a).rate === (b).rate;
         """
       )
 
@@ -265,9 +263,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
         returns: :boolean,
         body: """
         RETURN (a).seconds <> (b.seconds)
-          OR (a).rate.playback <> (b).rate.playback
-          OR NOT (a).rate.tags <@ (b).rate.tags
-          OR NOT (a).rate.tags @> (b).rate.tags;
+          OR (a).rate !=== (b).rate;
         """
       )
 

--- a/test/ecto/postgres/pg_framerate_test.exs
+++ b/test/ecto/postgres/pg_framerate_test.exs
@@ -364,7 +364,7 @@ defmodule Vtc.Ecto.Postgres.PgFramerateTest do
       },
       %{
         name: "negative denominator",
-        value: "((24000, -1001), '{non_drop}')",
+        value: "((24, -1), '{}')",
         field: :b,
         expected_code: :check_violation,
         expected_constraint: "b_positive"

--- a/test/ecto/postgres/pg_framerate_test.exs
+++ b/test/ecto/postgres/pg_framerate_test.exs
@@ -421,4 +421,94 @@ defmodule Vtc.Ecto.Postgres.PgFramerateTest do
       end
     end
   end
+
+  describe "Postgres framerate.is_ntsc/1" do
+    is_ntsc_table = [
+      %{input: Rates.f23_98(), expected: true},
+      %{input: Rates.f24(), expected: false},
+      %{input: Rates.f59_94_df(), expected: true},
+      %{input: Rates.f59_94_ndf(), expected: true}
+    ]
+
+    table_test "<%= input %> | <%= expected %>", is_ntsc_table, test_case do
+      %{input: input, expected: expected} = test_case
+
+      query = Query.from(f in fragment("SELECT framerate.is_ntsc(?) as r", type(^input, Framerate)), select: f.r)
+      result = Repo.one(query)
+
+      assert is_boolean(result)
+      assert result == expected
+    end
+
+    property "matches Framerate.ntsc?/1" do
+      check all(framerate <- StreamDataVtc.framerate()) do
+        query = Query.from(f in fragment("SELECT framerate.is_ntsc(?) as r", type(^framerate, Framerate)), select: f.r)
+        result = Repo.one(query)
+
+        assert is_boolean(result)
+        assert result == Framerate.ntsc?(framerate)
+      end
+    end
+  end
+
+  strict_eq_table = [
+    %{a: Rates.f23_98(), b: Rates.f23_98(), expected: true},
+    %{a: Rates.f23_98(), b: Rates.f24(), expected: false},
+    %{a: Rates.f23_98(), b: Framerate.new!(Ratio.new(24_000, 1001), ntsc: nil), expected: false},
+    %{a: Rates.f24(), b: Rates.f24(), expected: true},
+    %{a: Rates.f59_94_ndf(), b: Rates.f59_94_ndf(), expected: true},
+    %{a: Rates.f59_94_df(), b: Rates.f59_94_df(), expected: true},
+    %{a: Rates.f59_94_ndf(), b: Rates.f59_94_df(), expected: false},
+    %{a: Rates.f59_94_df(), b: Framerate.new!(Ratio.new(60_000, 1001), ntsc: nil), expected: false}
+  ]
+
+  describe "Postgres === (strict equality)" do
+    table_test "<%= a %> === <%= b %> | <%= expected %>", strict_eq_table, test_case do
+      %{a: a, b: b, expected: expected} = test_case
+
+      query = Query.from(f in fragment("SELECT ? === ? as r", type(^a, Framerate), type(^b, Framerate)), select: f.r)
+      result = Repo.one(query)
+
+      assert is_boolean(result)
+      assert result == expected
+    end
+
+    property "matches a == b" do
+      check all(
+              a <- StreamDataVtc.framerate(),
+              b <- StreamDataVtc.framerate()
+            ) do
+        query = Query.from(f in fragment("SELECT ? === ? as r", type(^a, Framerate), type(^b, Framerate)), select: f.r)
+        result = Repo.one(query)
+
+        assert is_boolean(result)
+        assert result == (a == b)
+      end
+    end
+  end
+
+  describe "Postgres === (strict not equality)" do
+    table_test "<%= a %> !=== <%= b %> | <%= expected %>", strict_eq_table, test_case do
+      %{a: a, b: b, expected: expected} = test_case
+
+      query = Query.from(f in fragment("SELECT ? !=== ? as r", type(^a, Framerate), type(^b, Framerate)), select: f.r)
+      result = Repo.one(query)
+
+      assert is_boolean(result)
+      refute result == expected
+    end
+
+    property "matches a != b" do
+      check all(
+              a <- StreamDataVtc.framerate(),
+              b <- StreamDataVtc.framerate()
+            ) do
+        query = Query.from(f in fragment("SELECT ? !=== ? as r", type(^a, Framerate), type(^b, Framerate)), select: f.r)
+        result = Repo.one(query)
+
+        assert is_boolean(result)
+        assert result == (a != b)
+      end
+    end
+  end
 end

--- a/test/ecto/postgres/pg_rational_test.exs
+++ b/test/ecto/postgres/pg_rational_test.exs
@@ -407,6 +407,30 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
   end
 
   describe "Postgres rational.round/1" do
+    round_table = [
+      %{input: Ratio.new(1), expected: 1},
+      %{input: Ratio.new(-1), expected: -1},
+      %{input: Ratio.new(1, 2), expected: 1},
+      %{input: Ratio.new(-1, 2), expected: -1},
+      %{input: Ratio.new(1, 4), expected: 0},
+      %{input: Ratio.new(-1, 4), expected: 0},
+      %{input: Ratio.new(3, 4), expected: 1},
+      %{input: Ratio.new(-3, 4), expected: -1}
+    ]
+
+    table_test "<%= input %> = <%= expected %>", round_table, test_case do
+      %{input: input, expected: expected} = test_case
+
+      query =
+        Query.from(f in fragment("SELECT rational.round(?) as r", type(^input, PgRational)),
+          select: f.r
+        )
+
+      result = Repo.one!(query)
+      assert is_integer(result)
+      assert result == expected
+    end
+
     property "matches Ratio" do
       check all(input <- StreamDataVtc.rational()) do
         query =

--- a/zdocs/quickstart.cheatmd
+++ b/zdocs/quickstart.cheatmd
@@ -391,7 +391,7 @@ those up.
 iex> a_in = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
 iex> a_out = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
 iex> 
-iex> a = Range.new!(a_in, a_out)
+iex> a = Framestamp.Range.new!(a_in, a_out)
 "<01:00:00:00 - 02:00:00:00 :exclusive <23.98 NTSC>>"
 ```
 
@@ -407,7 +407,7 @@ Just like addition, we can write a bare timecode string as the out value if we w
 ```elixir
 iex> b_in = Framestamp.with_frames!("01:45:00:00", Rates.f23_98())
 iex> 
-iex> b = Range.new!(b_in, "02:30:00:00")
+iex> b = Framestamp.Range.new!(b_in, "02:30:00:00")
 "<01:45:00:00 - 02:30:00:00 :exclusive <23.98 NTSC>>"
 ```
 
@@ -416,7 +416,7 @@ We can get the duration of a range.
 #### [duration/1](`Vtc.Framestamp.Range.duration/1`)
 
 ```elixir
-iex> Range.duration(b)
+iex> Framestamp.Range.duration(b)
 iex> "<00:45:00:00 <23.98 NTSC>>"
 ```
 
@@ -425,7 +425,7 @@ iex> "<00:45:00:00 <23.98 NTSC>>"
 #### [contains?/2](`Vtc.Framestamp.Range.contains?/2`)
 
 ```elixir
-iex> Range.contains?(b, "02:00:00:00")
+iex> Framestamp.Range.contains?(b, "02:00:00:00")
 iex> true
 ```
 
@@ -434,7 +434,7 @@ iex> true
 #### [overlaps?/2](`Vtc.Framestamp.Range.overlaps?/2`)
 
 ```elixir
-iex> Range.overlaps?(a, b)
+iex> Framestamp.Range.overlaps?(a, b)
 iex> true
 ```
 
@@ -443,7 +443,7 @@ We can even get the overlapping area as its own range!
 #### [intersection/2](`Vtc.Framestamp.Range.intersection/2`)
 
 ```elixir
-iex> Range.intersection!(a, b)
+iex> Framestamp.Range.intersection!(a, b)
 "<01:45:00:00 - 02:00:00:00 :exclusive <23.98 NTSC>>"
 ```
 


### PR DESCRIPTION
Adds `===` and `!===` operators for quickly checking that two framerates are strictly equal (both playback and tags match).

Also refactors/simplifies some of the rational postgres functions.