### PR TITLE
Create `PgFramestamp.Range` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,13 @@ depth walkthrough of what `Vtc` can do, or dive straight into the
       - [X] Native indexing support
     - Framerate[X]
     - Timecode[X]
-      - [ ] Native comparison operators
-      - [ ] Native arithmatic operators
-      - [ ] Native indexing Support
-      - [ ] Native inspection functions
+      - [X] Native comparison operators
+      - [X] Native arithmatic operators
+      - [X] Native indexing Support
+      - [X] Native inspection functions
     - Range
-      - [ ] Native indexing support
-      - [ ] Native inspection functions
+      - [X] Native indexing support
+      - [X] Native inspection functions
 
 ## Attributions
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,6 +23,11 @@ config :vtc, Vtc.Test.Support.Repo,
       functions_schema: :framestamp,
       functions_private_schema: :framestamp_private,
       functions_prefix: ""
+    ],
+    pg_framestamp_range: [
+      functions_schema: :framestamp_range,
+      functions_private_schema: :framestamp_range_private,
+      functions_prefix: ""
     ]
   ]
 

--- a/lib/ecto/postgres/pg_framerate.ex
+++ b/lib/ecto/postgres/pg_framerate.ex
@@ -129,6 +129,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate do
   Can be used in migrations as the fields type.
   """
   @impl Ecto.Type
+  @spec type() :: atom()
   def type, do: :framerate
 
   @typedoc """

--- a/lib/ecto/postgres/pg_framerate_migrations.ex
+++ b/lib/ecto/postgres/pg_framerate_migrations.ex
@@ -7,7 +7,6 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   """
   alias Ecto.Migration
   alias Vtc.Ecto.Postgres
-  alias Vtc.Ecto.Postgres.PgRational
 
   require Ecto.Migration
 
@@ -148,34 +147,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramerate.Migrations do
   section above.
   """
   @spec create_function_schemas() :: :ok
-  def create_function_schemas do
-    functions_schema = Postgres.Utils.get_type_config(Migration.repo(), :pg_framerate, :functions_schema, :public)
-
-    if functions_schema != :public do
-      Migration.execute("""
-        DO $$ BEGIN
-          CREATE SCHEMA #{functions_schema};
-          EXCEPTION WHEN duplicate_schema
-            THEN null;
-        END $$;
-      """)
-    end
-
-    functions_private_schema =
-      Postgres.Utils.get_type_config(Migration.repo(), :pg_framerate, :functions_private_schema, :public)
-
-    if functions_private_schema != :public do
-      Migration.execute("""
-        DO $$ BEGIN
-          CREATE SCHEMA #{functions_private_schema};
-          EXCEPTION WHEN duplicate_schema
-            THEN null;
-        END $$;
-      """)
-    end
-
-    :ok
-  end
+  def create_function_schemas, do: Postgres.Utils.create_type_schemas(:pg_framerate)
 
   @doc section: :migrations_functions
   @doc """

--- a/lib/ecto/postgres/pg_framestamp.ex
+++ b/lib/ecto/postgres/pg_framestamp.ex
@@ -119,6 +119,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp do
   Can be used in migrations as the fields type.
   """
   @impl Ecto.Type
+  @spec type() :: atom()
   def type, do: :framestamp
 
   @typedoc """

--- a/lib/ecto/postgres/pg_framestamp_migrations.ex
+++ b/lib/ecto/postgres/pg_framestamp_migrations.ex
@@ -152,34 +152,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   section above.
   """
   @spec create_function_schemas() :: :ok
-  def create_function_schemas do
-    functions_schema = Postgres.Utils.get_type_config(Migration.repo(), :pg_framestamp, :functions_schema, :public)
-
-    if functions_schema != :public do
-      Migration.execute("""
-        DO $$ BEGIN
-          CREATE SCHEMA #{functions_schema};
-          EXCEPTION WHEN duplicate_schema
-            THEN null;
-        END $$;
-      """)
-    end
-
-    functions_private_schema =
-      Postgres.Utils.get_type_config(Migration.repo(), :pg_framestamp, :functions_private_schema, :public)
-
-    if functions_private_schema != :public do
-      Migration.execute("""
-        DO $$ BEGIN
-          CREATE SCHEMA #{functions_private_schema};
-          EXCEPTION WHEN duplicate_schema
-            THEN null;
-        END $$;
-      """)
-    end
-
-    :ok
-  end
+  def create_function_schemas, do: Postgres.Utils.create_type_schemas(:pg_framestamp)
 
   @doc section: :migrations_functions
   @doc """

--- a/lib/ecto/postgres/pg_framestamp_range.ex
+++ b/lib/ecto/postgres/pg_framestamp_range.ex
@@ -1,0 +1,75 @@
+use Vtc.Ecto.Postgres.Utils
+
+defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Range do
+  use Ecto.Type
+
+  alias Vtc.Ecto.Postgres.PgFramestamp
+  alias Vtc.Framestamp
+
+  @doc section: :ecto_migrations
+  @doc """
+  The database type for [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`).
+
+  Can be used in migrations as the fields type.
+  """
+  @impl Ecto.Type
+  @spec type() :: atom()
+  def type, do: :framestamp_range
+
+  @typedoc """
+  Type of the raw composite value that will be sent to / received from the database.
+  """
+  @type db_record() :: %Postgrex.Range{
+          lower: PgFramestamp.db_record(),
+          lower_inclusive: boolean(),
+          upper: PgFramestamp.db_record(),
+          upper_inclusive: boolean()
+        }
+
+  # Handles casting PgRational fields in `Ecto.Changeset`s.
+  @doc false
+  @impl Ecto.Type
+  @spec cast(Framestamp.Range.t()) :: {:ok, Framestamp.Range.t()} | :error
+  def cast(%Framestamp.Range{} = range), do: {:ok, range}
+  def cast(_), do: :error
+
+  # Handles converting database records into Ratio structs to be used by the
+  # application.
+  @doc false
+  @impl Ecto.Type
+  @spec load(db_record()) :: {:ok, Framestamp.Range.t()} | :error
+  def load(%Postgrex.Range{} = db_record) do
+    out_type = if db_record.upper_inclusive, do: :inclusive, else: :exclusive
+
+    with {:ok, in_stamp} <- Framestamp.load(db_record.lower),
+         in_stamp = if(db_record.lower_inclusive, do: in_stamp, else: Framestamp.add(in_stamp, 1)),
+         {:ok, out_stamp} <- Framestamp.load(db_record.upper),
+         {:ok, _} = result <- Framestamp.Range.new(in_stamp, out_stamp, out_type: out_type) do
+      result
+    else
+      _ -> :error
+    end
+  end
+
+  def load(_), do: :error
+
+  # Handles converting `Framestamp.Range` structs into database records.
+  @doc false
+  @impl Ecto.Type
+  @spec dump(Framestamp.Range.t()) :: {:ok, db_record()} | :error
+  def dump(%Framestamp.Range{} = range) do
+    with {:ok, in_stamp_record} <- PgFramestamp.dump(range.in),
+         {:ok, out_stamp_record} <- PgFramestamp.dump(range.out) do
+      db_record = %Postgrex.Range{
+        lower: in_stamp_record,
+        lower_inclusive: true,
+        upper: out_stamp_record,
+        upper_inclusive: range.out_type == :inclusive
+      }
+
+      {:ok, db_record}
+    end
+  end
+
+  def dump(_), do: :error
+end

--- a/lib/ecto/postgres/pg_framestamp_range_migrations.ex
+++ b/lib/ecto/postgres/pg_framestamp_range_migrations.ex
@@ -1,0 +1,187 @@
+use Vtc.Ecto.Postgres.Utils
+
+defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Range.Migrations do
+  @moduledoc """
+  Migrations for adding framestamp range types, functions and constraints to a
+  Postgres database.
+  """
+  alias Ecto.Migration
+  alias Vtc.Ecto.Postgres
+  alias Vtc.Ecto.Postgres.PgFramestamp
+
+  require Ecto.Migration
+
+  @doc section: :migrations_full
+  @doc """
+  Adds raw SQL queries to a migration for creating the database types, associated
+  functions, casts, operators, and operator families.
+
+  Safe to run multiple times when new functionality is added in updates to this library.
+  Existing values will be skipped.
+
+  ## Types Created
+
+  Calling this macro creates the following type definitions:
+
+  ```sql
+  CREATE TYPE framestamp_range AS RANGE (
+    subtype = framestamp,
+  );
+  ```
+
+  ## Schemas Created
+
+  Up to two schemas are created as detailed by the
+  [Configuring Database Objects](Vtc.Ecto.Postgres.PgFramestamp.Range.Migrations.html#create_all/0-configuring-database-objects)
+  section below.
+
+  ## Configuring Database Objects
+
+  To change where supporting functions are created, add the following to your
+  Repo confiugration:
+
+  ```elixir
+  config :vtc, Vtc.Test.Support.Repo,
+    adapter: Ecto.Adapters.Postgres,
+    ...
+    vtc: [
+      pg_framestamp_range: [
+        functions_schema: :framestamp_range,
+        functions_private_schema: :framestamp_range_private,
+        functions_prefix: "framestamp_range"
+      ]
+    ]
+  ```
+
+  Option definitions are as follows:
+
+  - `functions_schema`: The schema for "public" functions that will have backwards
+    compatibility guarantees and application code support. Default: `:public`.
+
+  - `functions_private_schema:` The schema for for developer-only "private" functions
+    that support the functions in the "public" schema. Will NOT have backwards
+    compatibility guarantees NOR application code support. Default: `:public`.
+
+  - `functions_prefix`: A prefix to add before all functions. Defaults to
+    "framestamp_range" for any function created in the "public" schema, and ""
+    otherwise.
+
+  ## Examples
+
+  ```elixir
+  defmodule MyMigration do
+    use Ecto.Migration
+
+    alias Vtc.Ecto.Postgres.PgFramestamp
+    require PgFramestamp.Migrations
+
+    def change do
+      PgFramestamp.Range.Migrations.create_all()
+    end
+  end
+  ```
+  """
+  @spec create_all() :: :ok
+  def create_all do
+    create_function_schemas()
+
+    create_func_subtype_diff()
+    create_func_canonicalization()
+
+    create_type_framestamp_range()
+  end
+
+  @doc section: :migrations_types
+  @doc """
+  Adds `framestamp_range` composite type.
+  """
+  @spec create_type_framestamp_range() :: :ok
+  def create_type_framestamp_range do
+    subtype_diff = private_function(:subtype_diff, Migration.repo())
+
+    # As of now, pl/pgsql functions cannot be used to
+    canonicalization = private_function(:canonicalization, Migration.repo())
+
+    Migration.execute("""
+      DO $$ BEGIN
+        CREATE TYPE framestamp_range AS RANGE (
+          subtype = framestamp,
+          subtype_diff = #{subtype_diff},
+          canonical= #{canonicalization}
+        );
+        EXCEPTION WHEN duplicate_object
+          THEN null;
+      END $$;
+    """)
+  end
+
+  @doc section: :migrations_private_functions
+  @doc """
+  Creates `framestamp_private.subtype_diff(a, b)` used by the range type for more
+  efficient GiST indexes.
+  """
+  @spec create_func_subtype_diff() :: :ok
+  def create_func_subtype_diff do
+    create_func =
+      Postgres.Utils.create_plpgsql_function(
+        private_function(:subtype_diff, Migration.repo()),
+        args: [a: :framestamp, b: :framestamp],
+        declares: [diff: {:rational, "a - b"}],
+        returns: :"double precision",
+        body: """
+        RETURN CAST(diff as double precision);
+        """
+      )
+
+    Migration.execute(create_func)
+  end
+
+  @doc section: :migrations_private_functions
+  @doc """
+  Creates `framestamp_private.canonicalization(a, b, type)` used by the range
+  constructor to normalize ranges.
+
+  Output ranges have an inclusive lower bound and an exclusive upper bound.
+  """
+  @spec create_func_canonicalization() :: :ok
+  def create_func_canonicalization do
+    framestamp_with_frames = PgFramestamp.Migrations.function(:with_frames, Migration.repo())
+
+    create_func =
+      Postgres.Utils.create_plpgsql_function(
+        private_function(:canonicalization, Migration.repo()),
+        args: [input: :framestamp_range, range_type: :text],
+        declares: [single_frame: {:framestamp, "#{framestamp_with_frames}(1, (LOWER(input)).rate)"}],
+        returns: :framestamp_range,
+        body: """
+        CASE
+          WHEN range_type = '[)' THEN
+            RETURN input;
+          WHEN range_type = '[]' THEN
+            RETURN framestamp_range(LOWER(input), UPPER(INPUT) + single_frame, '[)');
+          WHEN range_type = '()' THEN
+            RETURN framestamp_range(LOWER(input) + single_frame, UPPER(INPUT), '[)');
+          WHEN range_type = '(]' THEN
+            RETURN framestamp_range(LOWER(input) + single_frame, UPPER(INPUT) + single_frame, '[)');
+        END CASE;
+        """
+      )
+
+    Migration.execute(create_func)
+  end
+
+  @doc section: :migrations_types
+  @doc """
+  Up to two schemas are created as detailed by the
+  [Configuring Database Objects](Vtc.Ecto.Postgres.PgRational.Migrations.html#create_all/0-configuring-database-objects)
+  section above.
+  """
+  @spec create_function_schemas() :: :ok
+  def create_function_schemas, do: Postgres.Utils.create_type_schemas(:pg_framestamp_range)
+
+  @spec private_function(atom(), Ecto.Repo.t()) :: String.t()
+  defp private_function(name, repo) do
+    function_prefix = Postgres.Utils.type_private_function_prefix(repo, :pg_framestamp_range)
+    "#{function_prefix}#{name}"
+  end
+end

--- a/lib/ecto/postgres/pg_rational.ex
+++ b/lib/ecto/postgres/pg_rational.ex
@@ -92,6 +92,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational do
   Can be used in migrations as the fields type.
   """
   @impl Ecto.Type
+  @spec type() :: atom()
   def type, do: :rational
 
   @typedoc """

--- a/lib/ecto/postgres/pg_rational_migrations.ex
+++ b/lib/ecto/postgres/pg_rational_migrations.ex
@@ -182,34 +182,7 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   section above.
   """
   @spec create_function_schemas() :: :ok
-  def create_function_schemas do
-    functions_schema = Postgres.Utils.get_type_config(Migration.repo(), :pg_rational, :functions_schema, :public)
-
-    if functions_schema != :public do
-      Migration.execute("""
-        DO $$ BEGIN
-          CREATE SCHEMA #{functions_schema};
-          EXCEPTION WHEN duplicate_schema
-            THEN null;
-        END $$;
-      """)
-    end
-
-    functions_private_schema =
-      Postgres.Utils.get_type_config(Migration.repo(), :pg_rational, :functions_private_schema, :public)
-
-    if functions_private_schema != :public do
-      Migration.execute("""
-        DO $$ BEGIN
-          CREATE SCHEMA #{functions_private_schema};
-          EXCEPTION WHEN duplicate_schema
-            THEN null;
-        END $$;
-      """)
-    end
-
-    :ok
-  end
+  def create_function_schemas, do: Postgres.Utils.create_type_schemas(:pg_rational)
 
   @doc section: :migrations_private_functions
   @doc """

--- a/lib/framestamp_range.ex
+++ b/lib/framestamp_range.ex
@@ -20,7 +20,9 @@ defmodule Vtc.Framestamp.Range do
   In mathematical notation, inclusive ranges are `[in, out]`, while exclusive ranges are
   `[in, out)`.
   """
+  use Vtc.Ecto.Postgres.Utils
 
+  alias Vtc.Ecto.Postgres.PgFramestamp
   alias Vtc.Framestamp
   alias Vtc.Source.Frames
 
@@ -560,6 +562,26 @@ defmodule Vtc.Framestamp.Range do
       %__MODULE__{} = range -> with_out_type(range, out_type)
       value -> value
     end)
+  end
+
+  when_pg_enabled do
+    use Ecto.Type
+
+    @impl Ecto.Type
+    @spec type() :: atom()
+    defdelegate type, to: PgFramestamp.Range
+
+    @impl Ecto.Type
+    @spec cast(t() | %{String.t() => any()} | %{atom() => any()}) :: {:ok, t()} | :error
+    defdelegate cast(value), to: PgFramestamp.Range
+
+    @impl Ecto.Type
+    @spec load(PgFramestamp.Range.db_record()) :: {:ok, t()} | :error
+    defdelegate load(value), to: PgFramestamp.Range
+
+    @impl Ecto.Type
+    @spec dump(t()) :: {:ok, PgFramestamp.Range.db_record()} | :error
+    defdelegate dump(value), to: PgFramestamp.Range
   end
 end
 

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,9 @@ defmodule Vtc.MixProject do
             Vtc.Ecto.Postgres.PgFramerate,
             Vtc.Ecto.Postgres.PgFramerate.Migrations,
             Vtc.Ecto.Postgres.PgFramestamp,
-            Vtc.Ecto.Postgres.PgFramestamp.Migrations
+            Vtc.Ecto.Postgres.PgFramestamp.Migrations,
+            Vtc.Ecto.Postgres.PgFramestamp.Range,
+            Vtc.Ecto.Postgres.PgFramestamp.Range.Migrations
           ],
           "Test Utilities": [Vtc.TestUtls.StreamDataVtc]
         ],

--- a/priv/repo/migrations/20230706223647_add_framestamp_range_type.exs
+++ b/priv/repo/migrations/20230706223647_add_framestamp_range_type.exs
@@ -1,0 +1,11 @@
+defmodule Vtc.Test.Support.Repo.Migrations.AddFramestampRangeType do
+  @moduledoc false
+  use Ecto.Migration
+
+  alias Vtc.Ecto.Postgres.PgFramestamp
+
+  def change do
+    :ok = PgFramestamp.Range.Migrations.create_all()
+    :ok = PgFramestamp.Range.Migrations.create_all()
+  end
+end

--- a/priv/repo/migrations/20230708203542_add_framestamp_schema_02.exs
+++ b/priv/repo/migrations/20230708203542_add_framestamp_schema_02.exs
@@ -1,0 +1,25 @@
+defmodule Vtc.Test.Support.Repo.Migrations.AddFramestampSchema02 do
+  @moduledoc false
+  use Ecto.Migration
+
+  alias Vtc.Ecto.Postgres.PgFramestamp
+  alias Vtc.Framestamp
+
+  def change do
+    create table("framestamps_02", primary_key: false) do
+      add(:id, :uuid, primary_key: true, null: false)
+      add(:a, Framestamp.type(), null: false)
+      add(:b, Framestamp.type(), null: false)
+    end
+
+    :ok = PgFramestamp.Migrations.create_field_constraints("framestamps_02", :b)
+
+    create(index("framestamps_02", [:b]))
+
+    execute("""
+      CREATE INDEX framestamps_a_b_range
+        ON framestamps_02
+        USING GIST(framestamp_fastrange(a, b))
+    """)
+  end
+end

--- a/test/ecto/postgres/pg_framestamp_range_test.exs
+++ b/test/ecto/postgres/pg_framestamp_range_test.exs
@@ -5,68 +5,536 @@ defmodule Vtc.Ecto.Postgres.PgFramestampRangeTest do
   alias Ecto.Query
   alias Vtc.Framestamp
   alias Vtc.Rates
+  alias Vtc.Test.Support.CommonTables
+  alias Vtc.TestUtls.StreamDataVtc
 
   require Ecto.Query
 
   describe "#SELECT" do
-    test "can construct exclusive range using type/2 fragment" do
-      in_stamp = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
-      out_stamp = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
-      stamp_range = Framestamp.Range.new!(in_stamp, out_stamp)
+    setup context, do: TestCase.setup_ranges(context)
 
-      query = Query.from(f in fragment("SELECT ? as r", type(^stamp_range, Framestamp.Range)), select: f.r)
+    @describetag ranges: [:input, :expected]
+
+    canonical_table = [
+      %{
+        input: {"01:00:00:00", "02:00:00:00"},
+        expected: {"01:00:00:00", "02:00:00:00"}
+      },
+      %{
+        input: {"01:00:00:00", "02:00:00:00", :inclusive},
+        expected: {"01:00:00:00", "02:00:00:01"}
+      }
+    ]
+
+    table_test "type/2 fragment canonicalized to :inclusive range | <%= input %>", canonical_table, test_case do
+      %{input: input, expected: expected} = test_case
+
+      query = Query.from(f in fragment("SELECT ? as r", type(^input, Framestamp.Range)), select: f.r)
 
       assert %Postgrex.Range{} = result = Repo.one!(query)
-      assert {:ok, ^stamp_range} = Framestamp.Range.load(result)
+      assert {:ok, ^expected} = Framestamp.Range.load(result)
     end
 
-    test "can construct inclusive range using type/2 fragment" do
-      in_stamp = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
-      out_stamp = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
-      stamp_range = Framestamp.Range.new!(in_stamp, out_stamp, out_type: :inclusive)
-
-      query = Query.from(f in fragment("SELECT ? as r", type(^stamp_range, Framestamp.Range)), select: f.r)
-
-      assert %Postgrex.Range{} = result = Repo.one!(query)
-      assert {:ok, ^stamp_range} = Framestamp.Range.load(result)
-    end
-
-    test "can construct exclusive range using native cast" do
-      in_stamp = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
-      out_stamp = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
-      stamp_range = Framestamp.Range.new!(in_stamp, out_stamp)
+    table_test "native cast canonicalized to :inclusive range | <%= input %>", canonical_table, test_case do
+      %{input: %{in: in_stamp, out: out_stamp} = input, expected: expected} = test_case
+      range_bounds = if input.out_type == :exclusive, do: "[)", else: "[]"
 
       query =
         Query.from(
           f in fragment(
-            "SELECT framestamp_range(?, ?, '[)') as r",
+            "SELECT framestamp_range(?, ?, ?) as r",
             type(^in_stamp, Framestamp),
-            type(^out_stamp, Framestamp)
+            type(^out_stamp, Framestamp),
+            ^range_bounds
           ),
           select: f.r
         )
 
       assert %Postgrex.Range{} = result = Repo.one!(query)
-      assert {:ok, ^stamp_range} = Framestamp.Range.load(result)
+      assert {:ok, ^expected} = Framestamp.Range.load(result)
     end
+  end
 
-    test "can construct inclusive range using native cast" do
-      in_stamp = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
-      out_stamp = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
-      stamp_range = Framestamp.Range.new!(in_stamp, out_stamp, out_type: :inclusive)
+  describe "Postgres @> and <@ (contains)" do
+    setup context, do: TestCase.setup_framestamps(context)
+    setup context, do: TestCase.setup_ranges(context)
+    setup context, do: TestCase.setup_negates(context)
+
+    @describetag framestamps: [:framestamp]
+    @describetag ranges: [:range]
+
+    table_test "<%= name %> | @>", CommonTables.range_contains(), test_case do
+      %{range: range, framestamp: framestamp, expected: expected} = test_case
 
       query =
         Query.from(
           f in fragment(
-            "SELECT framestamp_range(?, ?, '[]') as r",
-            type(^in_stamp, Framestamp),
-            type(^out_stamp, Framestamp)
+            "SELECT ? @> ? as r",
+            type(^range, Framestamp.Range),
+            type(^framestamp, Framestamp)
+          ),
+          select: f.r
+        )
+
+      assert Repo.one!(query) == expected
+    end
+
+    table_test "<%= name %> | not @>", CommonTables.range_contains(), test_case do
+      %{range: range, framestamp: framestamp, expected: expected} = test_case
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT not ? @> ? as r",
+            type(^range, Framestamp.Range),
+            type(^framestamp, Framestamp)
+          ),
+          select: f.r
+        )
+
+      refute Repo.one!(query) == expected
+    end
+
+    @tag negate: [:range, :framestamp]
+    table_test "<%= name %> | @> | negative", CommonTables.range_contains(), test_case do
+      %{range: range, framestamp: framestamp, expected_negative: expected} = test_case
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT ? @> ? as r",
+            type(^range, Framestamp.Range),
+            type(^framestamp, Framestamp)
+          ),
+          select: f.r
+        )
+
+      assert Repo.one!(query) == expected
+    end
+
+    @tag negate: [:range, :framestamp]
+    table_test "<%= name %> | not @> | negative", CommonTables.range_contains(), test_case do
+      %{range: range, framestamp: framestamp, expected_negative: expected} = test_case
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT not ? @> ? as r",
+            type(^range, Framestamp.Range),
+            type(^framestamp, Framestamp)
+          ),
+          select: f.r
+        )
+
+      refute Repo.one!(query) == expected
+    end
+
+    table_test "<%= name %> | <@", CommonTables.range_contains(), test_case do
+      %{range: range, framestamp: framestamp, expected: expected} = test_case
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT ? <@ ? as r",
+            type(^framestamp, Framestamp),
+            type(^range, Framestamp.Range)
+          ),
+          select: f.r
+        )
+
+      assert Repo.one!(query) == expected
+    end
+
+    @tag negate: [:range, :framestamp]
+    table_test "<%= name %> | <@ | negative", CommonTables.range_contains(), test_case do
+      %{range: range, framestamp: framestamp, expected_negative: expected} = test_case
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT ? <@ ? as r",
+            type(^framestamp, Framestamp),
+            type(^range, Framestamp.Range)
+          ),
+          select: f.r
+        )
+
+      assert Repo.one!(query) == expected
+    end
+
+    property "@> | matches Framestamp.Range.contains?/2" do
+      check all(
+              range <- StreamDataVtc.framestamp_range(),
+              framestamp <- StreamDataVtc.framestamp()
+            ) do
+        query =
+          Query.from(
+            f in fragment(
+              "SELECT ? @> ? as r",
+              type(^range, Framestamp.Range),
+              type(^framestamp, Framestamp)
+            ),
+            select: f.r
+          )
+
+        assert Repo.one!(query) == Framestamp.Range.contains?(range, framestamp)
+      end
+    end
+
+    property "<@ | matches Framestamp.Range.contains?/2" do
+      check all(
+              range <- StreamDataVtc.framestamp_range(),
+              framestamp <- StreamDataVtc.framestamp()
+            ) do
+        query =
+          Query.from(
+            f in fragment(
+              "SELECT ? <@ ? as r",
+              type(^framestamp, Framestamp),
+              type(^range, Framestamp.Range)
+            ),
+            select: f.r
+          )
+
+        assert Repo.one!(query) == Framestamp.Range.contains?(range, framestamp)
+      end
+    end
+  end
+
+  describe "Postgres && (overlaps)" do
+    setup context, do: TestCase.setup_ranges(context)
+    setup context, do: TestCase.setup_negates(context)
+
+    @describetag framestamps: [:framestamp]
+    @describetag ranges: [:a, :b]
+
+    table_test "<%= name %> | :eclusive", CommonTables.range_overlaps(), test_case do
+      run_overlaps_select_test(test_case)
+    end
+
+    table_test "<%= name %> | :exclusive | flipped", CommonTables.range_overlaps(), test_case,
+      if: test_case.a != test_case.b do
+      %{a: a, b: b} = test_case
+
+      test_case
+      |> Map.put(:a, b)
+      |> Map.put(:b, a)
+      |> run_overlaps_select_test()
+    end
+
+    @tag out_type: :inclusive
+    table_test "<%= name %> | :inclusive", CommonTables.range_overlaps(), test_case do
+      %{a: a, b: b} = test_case
+
+      a = Framestamp.Range.with_inclusive_out(a)
+      b = Framestamp.Range.with_inclusive_out(b)
+
+      test_case
+      |> Map.put(:a, a)
+      |> Map.put(:b, b)
+      |> run_overlaps_select_test()
+    end
+
+    @tag out_type: :inclusive
+    table_test "<%= name %> | :inclusive | flipped", CommonTables.range_overlaps(), test_case,
+      if: test_case.a != test_case.b do
+      %{a: a, b: b} = test_case
+
+      a = Framestamp.Range.with_inclusive_out(a)
+      b = Framestamp.Range.with_inclusive_out(b)
+
+      test_case
+      |> Map.put(:a, b)
+      |> Map.put(:b, a)
+      |> run_overlaps_select_test()
+    end
+
+    @tag negate: [:a, :b]
+    table_test "<%= name %> | && | negative", CommonTables.range_overlaps(), test_case do
+      run_overlaps_select_test(test_case)
+    end
+
+    @tag negate: [:a, :b]
+    table_test "<%= name %> | && | negative | flipped", CommonTables.range_overlaps(), test_case do
+      %{a: a, b: b} = test_case
+
+      test_case
+      |> Map.put(:a, b)
+      |> Map.put(:b, a)
+      |> run_overlaps_select_test()
+    end
+
+    table_test "<%= name %> | not &&", CommonTables.range_overlaps(), test_case do
+      run_not_overlaps_select_test(test_case)
+    end
+
+    @tag negate: [:a, :b]
+    table_test "<%= name %> | not && | negative", CommonTables.range_overlaps(), test_case do
+      run_not_overlaps_select_test(test_case)
+    end
+
+    @spec run_overlaps_select_test(map()) :: :ok
+    defp run_overlaps_select_test(test_case) do
+      %{a: a, b: b, expected: expected} = test_case
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT ? && ? as r",
+            type(^a, Framestamp.Range),
+            type(^b, Framestamp.Range)
+          ),
+          select: f.r
+        )
+
+      assert Repo.one!(query) == expected
+
+      :ok
+    end
+
+    @spec run_not_overlaps_select_test(map()) :: :ok
+    defp run_not_overlaps_select_test(test_case) do
+      %{a: a, b: b, expected: expected} = test_case
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT not ? && ? as r",
+            type(^a, Framestamp.Range),
+            type(^b, Framestamp.Range)
+          ),
+          select: f.r
+        )
+
+      refute Repo.one!(query) == expected
+
+      :ok
+    end
+
+    property "matches Framestamp.Range.overlaps?/2" do
+      check all(
+              a <- StreamDataVtc.framestamp_range(filter_empty?: true),
+              b <- StreamDataVtc.framestamp_range(filter_empty?: true)
+            ) do
+        query =
+          Query.from(
+            f in fragment(
+              "SELECT ? && ? as r",
+              type(^a, Framestamp.Range),
+              type(^b, Framestamp.Range)
+            ),
+            select: f.r
+          )
+
+        assert Repo.one!(query) == Framestamp.Range.overlaps?(a, b)
+      end
+    end
+  end
+
+  describe "Postgres * (intersection)" do
+    setup context, do: TestCase.setup_ranges(context)
+    setup context, do: TestCase.setup_negates(context)
+
+    @describetag framestamps: [:framestamp]
+    @describetag ranges: [:a, :b, :expected]
+
+    table_test "<%= name %>", CommonTables.range_intersection(), test_case do
+      run_intersection_select_test(test_case)
+    end
+
+    table_test "<%= name %> | flipped", CommonTables.range_intersection(), test_case do
+      %{a: a, b: b} = test_case
+
+      test_case
+      |> Map.put(:a, b)
+      |> Map.put(:b, a)
+      |> run_intersection_select_test()
+    end
+
+    @tag negate: [:a, :b, :expected]
+    table_test "<%= name %> | negative", CommonTables.range_intersection(), test_case do
+      run_intersection_select_test(test_case)
+    end
+
+    @tag negate: [:a, :b, :expected]
+    table_test "<%= name %> | negative | flipped", CommonTables.range_intersection(), test_case do
+      %{a: a, b: b} = test_case
+
+      test_case
+      |> Map.put(:a, b)
+      |> Map.put(:b, a)
+      |> run_intersection_select_test()
+    end
+
+    @spec run_intersection_select_test(map()) :: :ok
+    defp run_intersection_select_test(test_case) do
+      %{a: a, b: b, expected: expected} = test_case
+
+      expected =
+        case expected do
+          {:error, :none} -> :error
+          expected -> {:ok, expected}
+        end
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT ? * ? as r",
+            type(^a, Framestamp.Range),
+            type(^b, Framestamp.Range)
+          ),
+          select: f.r
+        )
+
+      result = query |> Repo.one!() |> Framestamp.Range.load()
+      check_intersection_result(a, b, result, expected)
+
+      :ok
+    end
+
+    property "matches Framestamp.Range.intersection/2" do
+      check all(
+              a <- StreamDataVtc.framestamp_range(filter_empty?: true),
+              b <- StreamDataVtc.framestamp_range(filter_empty?: true)
+            ) do
+        expected =
+          case Framestamp.Range.intersection(a, b) do
+            {:ok, _} = result -> result
+            {:error, :none} -> :error
+          end
+
+        query =
+          Query.from(
+            f in fragment(
+              "SELECT ? * ? as r",
+              type(^a, Framestamp.Range),
+              type(^b, Framestamp.Range)
+            ),
+            select: f.r
+          )
+
+        result = query |> Repo.one!() |> Framestamp.Range.load()
+        check_intersection_result(a, b, result, expected)
+      end
+    end
+
+    @spec check_intersection_result(
+            Framestamp.Range.t(),
+            Framestamp.Range.t(),
+            {:ok, Framestamp.Range.t()} | :error,
+            {:ok, Framestamp.Range.t()} | :error
+          ) :: :ok
+    defp check_intersection_result(a, b, result, expected) do
+      cond do
+        expected == :error ->
+          assert result == expected
+
+        a.in.rate != b.in.rate ->
+          {:ok, expected} = expected
+          assert {:ok, result} = result
+          expected_inverse = Framestamp.Range.intersection!(b, a)
+          expected_flipped_inverse = Framestamp.Range.intersection!(a, b)
+
+          assert result.in.rate == result.out.rate
+
+          assert result.in == expected.in or
+                   result.in == expected_inverse.in or
+                   result.in == expected_flipped_inverse.in
+
+          assert result.out == expected.out or
+                   result.out == expected_inverse.out or
+                   result.out == expected_flipped_inverse.out
+
+        true ->
+          assert result == expected
+      end
+
+      :ok
+    end
+  end
+
+  describe "#SELECT fastrange/2" do
+    test "can construct fastrange" do
+      stamp_01 = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
+      stamp_02 = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT framestamp_fastrange(?, ?) as r",
+            type(^stamp_01, Framestamp),
+            type(^stamp_02, Framestamp)
           ),
           select: f.r
         )
 
       assert %Postgrex.Range{} = result = Repo.one!(query)
-      assert {:ok, ^stamp_range} = Framestamp.Range.load(result)
+      assert result.lower == Ratio.to_float(stamp_01.seconds)
+      assert result.upper == Ratio.to_float(stamp_02.seconds)
+    end
+
+    property "can construct fastrange from two framestamps" do
+      check all(range <- StreamDataVtc.framestamp_range(filter_empty?: true)) do
+        stamp_in = range.in
+        stamp_out = range.out
+
+        query =
+          Query.from(
+            f in fragment(
+              "SELECT framestamp_fastrange(?, ?) as r",
+              type(^stamp_in, Framestamp),
+              type(^stamp_out, Framestamp)
+            ),
+            select: f.r
+          )
+
+        assert %Postgrex.Range{} = result = Repo.one!(query)
+        assert result.lower == Ratio.to_float(stamp_in.seconds)
+        assert result.upper == Ratio.to_float(stamp_out.seconds)
+      end
+    end
+
+    test "can construct fastrange from Framestamp.Range" do
+      stamp_01 = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
+      stamp_02 = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
+      range = Framestamp.Range.new!(stamp_01, stamp_02)
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT framestamp_fastrange(?) as r",
+            type(^range, Framestamp.Range)
+          ),
+          select: f.r
+        )
+
+      assert %Postgrex.Range{} = result = Repo.one!(query)
+      assert result.lower == Ratio.to_float(stamp_01.seconds)
+      assert result.lower_inclusive == true
+      assert result.upper == Ratio.to_float(stamp_02.seconds)
+      assert result.upper_inclusive == false
+    end
+
+    test "can construct fastrange from exclusive Framestamp.Range" do
+      stamp_01 = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
+      stamp_02 = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
+      range = Framestamp.Range.new!(stamp_01, stamp_02, out_type: :inclusive)
+      expected = Framestamp.Range.with_exclusive_out(range)
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT framestamp_fastrange(?) as r",
+            type(^range, Framestamp.Range)
+          ),
+          select: f.r
+        )
+
+      assert %Postgrex.Range{} = result = Repo.one!(query)
+      assert result.lower == Ratio.to_float(expected.in.seconds)
+      assert result.lower_inclusive == true
+      assert result.upper == Ratio.to_float(expected.out.seconds)
+      assert result.upper_inclusive == false
     end
   end
 end

--- a/test/ecto/postgres/pg_framestamp_range_test.exs
+++ b/test/ecto/postgres/pg_framestamp_range_test.exs
@@ -1,0 +1,72 @@
+defmodule Vtc.Ecto.Postgres.PgFramestampRangeTest do
+  use Vtc.Test.Support.EctoCase, async: true
+  use ExUnitProperties
+
+  alias Ecto.Query
+  alias Vtc.Framestamp
+  alias Vtc.Rates
+
+  require Ecto.Query
+
+  describe "#SELECT" do
+    test "can construct exclusive range using type/2 fragment" do
+      in_stamp = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
+      out_stamp = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
+      stamp_range = Framestamp.Range.new!(in_stamp, out_stamp)
+
+      query = Query.from(f in fragment("SELECT ? as r", type(^stamp_range, Framestamp.Range)), select: f.r)
+
+      assert %Postgrex.Range{} = result = Repo.one!(query)
+      assert {:ok, ^stamp_range} = Framestamp.Range.load(result)
+    end
+
+    test "can construct inclusive range using type/2 fragment" do
+      in_stamp = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
+      out_stamp = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
+      stamp_range = Framestamp.Range.new!(in_stamp, out_stamp, out_type: :inclusive)
+
+      query = Query.from(f in fragment("SELECT ? as r", type(^stamp_range, Framestamp.Range)), select: f.r)
+
+      assert %Postgrex.Range{} = result = Repo.one!(query)
+      assert {:ok, ^stamp_range} = Framestamp.Range.load(result)
+    end
+
+    test "can construct exclusive range using native cast" do
+      in_stamp = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
+      out_stamp = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
+      stamp_range = Framestamp.Range.new!(in_stamp, out_stamp)
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT framestamp_range(?, ?, '[)') as r",
+            type(^in_stamp, Framestamp),
+            type(^out_stamp, Framestamp)
+          ),
+          select: f.r
+        )
+
+      assert %Postgrex.Range{} = result = Repo.one!(query)
+      assert {:ok, ^stamp_range} = Framestamp.Range.load(result)
+    end
+
+    test "can construct inclusive range using native cast" do
+      in_stamp = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
+      out_stamp = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
+      stamp_range = Framestamp.Range.new!(in_stamp, out_stamp, out_type: :inclusive)
+
+      query =
+        Query.from(
+          f in fragment(
+            "SELECT framestamp_range(?, ?, '[]') as r",
+            type(^in_stamp, Framestamp),
+            type(^out_stamp, Framestamp)
+          ),
+          select: f.r
+        )
+
+      assert %Postgrex.Range{} = result = Repo.one!(query)
+      assert {:ok, ^stamp_range} = Framestamp.Range.load(result)
+    end
+  end
+end

--- a/test/ecto/postgres/pg_framestamp_test.exs
+++ b/test/ecto/postgres/pg_framestamp_test.exs
@@ -530,7 +530,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
 
     @tag framestamps: [:a, :b]
-    table_test "can be used in WHERE table.field | <%= a %> = <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "can be used in WHERE table.field | <%= a %> = <%= b %>", CommonTables.framestamp_compare(), test_case do
       test_case
       |> Map.update(:expected, nil, &(&1 == :eq))
       |> run_table_comparison_test(fn query -> Query.where(query, [r], r.a == r.b) end)
@@ -560,7 +560,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
 
     @tag framestamps: [:a, :b]
-    table_test "can be used in WHERE table.field | <%= a %> === <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "can be used in WHERE table.field | <%= a %> === <%= b %>", CommonTables.framestamp_compare(), test_case do
       test_case
       |> Map.update(:expected, nil, &(&1 == :eq and test_case.a.rate == test_case.b.rate))
       |> run_table_comparison_test(fn query -> Query.where(query, [r], fragment("? === ?", r.a, r.b)) end)
@@ -605,14 +605,18 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
 
     @tag framestamps: [:a, :b]
-    table_test "<> can be used in WHERE table.field | <%= a %> <> <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "<> can be used in WHERE table.field | <%= a %> <> <%= b %>",
+               CommonTables.framestamp_compare(),
+               test_case do
       test_case
       |> Map.update(:expected, nil, &(&1 != :eq))
       |> run_table_comparison_test(fn query -> Query.where(query, [r], fragment("? <> ?", r.a, r.b)) end)
     end
 
     @tag framestamps: [:a, :b]
-    table_test "!= can be used in WHERE table.field | <%= a %> != <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "!= can be used in WHERE table.field | <%= a %> != <%= b %>",
+               CommonTables.framestamp_compare(),
+               test_case do
       test_case
       |> Map.update(:expected, nil, &(&1 != :eq))
       |> run_table_comparison_test(fn query -> Query.where(query, [r], r.a != r.b) end)
@@ -642,7 +646,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
 
     @tag framestamps: [:a, :b]
-    table_test "can be used in WHERE table.field | <%= a %> === <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "can be used in WHERE table.field | <%= a %> === <%= b %>", CommonTables.framestamp_compare(), test_case do
       test_case
       |> Map.update(:expected, nil, &(&1 != :eq or test_case.a.rate != test_case.b.rate))
       |> run_table_comparison_test(fn query -> Query.where(query, [r], fragment("? !=== ?", r.a, r.b)) end)
@@ -670,7 +674,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
 
     @tag framestamps: [:a, :b]
-    table_test "can be used in WHERE table.field | <%= a %> < <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "can be used in WHERE table.field | <%= a %> < <%= b %>", CommonTables.framestamp_compare(), test_case do
       test_case
       |> Map.update(:expected, nil, &(&1 == :lt))
       |> run_table_comparison_test(fn query -> Query.where(query, [r], r.a < r.b) end)
@@ -698,7 +702,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
 
     @tag framestamps: [:a, :b]
-    table_test "can be used in WHERE table.field | <%= a %> <= <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "can be used in WHERE table.field | <%= a %> <= <%= b %>", CommonTables.framestamp_compare(), test_case do
       test_case
       |> Map.update(:expected, nil, &(&1 in [:lt, :eq]))
       |> run_table_comparison_test(fn query -> Query.where(query, [r], r.a <= r.b) end)
@@ -726,7 +730,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
 
     @tag framestamps: [:a, :b]
-    table_test "can be used in WHERE table.field | <%= a %> > <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "can be used in WHERE table.field | <%= a %> > <%= b %>", CommonTables.framestamp_compare(), test_case do
       test_case
       |> Map.update(:expected, nil, &(&1 == :gt))
       |> run_table_comparison_test(fn query -> Query.where(query, [r], r.a > r.b) end)
@@ -754,7 +758,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
 
     @tag framestamps: [:a, :b]
-    table_test "can be used in WHERE table.field | <%= a %> >= <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "can be used in WHERE table.field | <%= a %> >= <%= b %>", CommonTables.framestamp_compare(), test_case do
       test_case
       |> Map.update(:expected, nil, &(&1 in [:gt, :eq]))
       |> run_table_comparison_test(fn query -> Query.where(query, [r], r.a >= r.b) end)
@@ -790,7 +794,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
 
     @tag framestamps: [:a, :b]
-    table_test "can be used in WHERE table.field | <%= a %> >= <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "can be used in WHERE table.field | <%= a %> >= <%= b %>", CommonTables.framestamp_compare(), test_case do
       expected =
         case test_case.expected do
           :lt -> -1
@@ -868,7 +872,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
-    table_test "<%= a %> + <%= b %> == <%= expected %>", CommonTables.add_table(), test_case do
+    table_test "<%= a %> + <%= b %> == <%= expected %>", CommonTables.framestamp_add(), test_case do
       %{a: a, b: b, expected: expected} = test_case
 
       query =
@@ -916,7 +920,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
-    table_test "<%= a %> - <%= b %> == <%= expected %>", CommonTables.subtract_table(), test_case do
+    table_test "<%= a %> - <%= b %> == <%= expected %>", CommonTables.framestamp_subtract(), test_case do
       %{a: a, b: b, expected: expected} = test_case
 
       query =

--- a/test/framestamp/framestamp_ops_test.exs
+++ b/test/framestamp/framestamp_ops_test.exs
@@ -66,41 +66,37 @@ defmodule Vtc.FramestampTest.Ops do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b]
 
-    table_test "<%= a %> is <%= expected %> <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "<%= a %> is <%= expected %> <%= b %>", CommonTables.framestamp_compare(), test_case do
       %{a: a, b: b, expected: expected} = test_case
       assert Framestamp.compare(a, b) == expected
     end
 
-    name = "<%= a %> is <%= expected %> <%= b %> | b = tc string"
-
-    table_test name, CommonTables.compare_table(), test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
+    table_test "<%= a %> is <%= expected %> <%= b %> | b = tc string", CommonTables.framestamp_compare(), test_case,
+      if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       b = Framestamp.smpte_timecode(b)
 
       assert Framestamp.compare(a, b) == expected
     end
 
-    name = "<%= a %> is <%= expected %> <%= b %> | a = tc string"
-
-    table_test name, CommonTables.compare_table(), test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
+    table_test "<%= a %> is <%= expected %> <%= b %> | a = tc string", CommonTables.framestamp_compare(), test_case,
+      if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       a = Framestamp.smpte_timecode(a)
 
       assert Framestamp.compare(a, b) == expected
     end
 
-    name = "<%= a %> is <%= expected %> <%= b %> | b = frames int"
-
-    table_test name, CommonTables.compare_table(), test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
+    table_test "<%= a %> is <%= expected %> <%= b %> | b = frames int", CommonTables.framestamp_compare(), test_case,
+      if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       b = Framestamp.frames(b)
 
       assert Framestamp.compare(a, b) == expected
     end
 
-    name = "<%= a %> is <%= expected %> <%= b %> | a = frames int"
-
-    table_test name, CommonTables.compare_table(), test_case, if: is_binary(test_case.a) and is_binary(test_case.b) do
+    table_test "<%= a %> is <%= expected %> <%= b %> | a = frames int", CommonTables.framestamp_compare(), test_case,
+      if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       a = Framestamp.frames(a)
 
@@ -126,7 +122,7 @@ defmodule Vtc.FramestampTest.Ops do
       refute Framestamp.eq?(a, b)
     end
 
-    table_test "<%= a %>, <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "<%= a %>, <%= b %>", CommonTables.framestamp_compare(), test_case do
       %{a: a, b: b, expected: cmp_expected} = test_case
       expected = cmp_expected == :eq
 
@@ -159,7 +155,7 @@ defmodule Vtc.FramestampTest.Ops do
       refute Framestamp.lt?(a, b)
     end
 
-    table_test "<%= a %>, <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "<%= a %>, <%= b %>", CommonTables.framestamp_compare(), test_case do
       %{a: a, b: b, expected: cmp_expected} = test_case
       expected = cmp_expected == :lt
 
@@ -192,7 +188,7 @@ defmodule Vtc.FramestampTest.Ops do
       refute Framestamp.lte?(a, b)
     end
 
-    table_test "<%= a %>, <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "<%= a %>, <%= b %>", CommonTables.framestamp_compare(), test_case do
       %{a: a, b: b, expected: cmp_expected} = test_case
       expected = cmp_expected in [:lt, :eq]
 
@@ -225,7 +221,7 @@ defmodule Vtc.FramestampTest.Ops do
       refute Framestamp.gt?(a, b)
     end
 
-    table_test "<%= a %>, <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "<%= a %>, <%= b %>", CommonTables.framestamp_compare(), test_case do
       %{a: a, b: b, expected: cmp_expected} = test_case
       expected = cmp_expected == :gt
 
@@ -258,7 +254,7 @@ defmodule Vtc.FramestampTest.Ops do
       refute Framestamp.gte?(a, b)
     end
 
-    table_test "<%= a %>, <%= b %>", CommonTables.compare_table(), test_case do
+    table_test "<%= a %>, <%= b %>", CommonTables.framestamp_compare(), test_case do
       %{a: a, b: b, expected: cmp_expected} = test_case
       expected = cmp_expected in [:gt, :eq]
 
@@ -270,12 +266,12 @@ defmodule Vtc.FramestampTest.Ops do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
-    table_test "<%= a %> + <%= b %> == <%= expected %>", CommonTables.add_table(), test_case do
+    table_test "<%= a %> + <%= b %> == <%= expected %>", CommonTables.framestamp_add(), test_case do
       %{a: a, b: b, expected: expected} = test_case
       assert Framestamp.add(a, b) == expected
     end
 
-    table_test "<%= a %> + <%= b %> == <%= expected %> | integer b", CommonTables.add_table(), test_case,
+    table_test "<%= a %> + <%= b %> == <%= expected %> | integer b", CommonTables.framestamp_add(), test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       b = Framestamp.frames(b)
@@ -283,7 +279,7 @@ defmodule Vtc.FramestampTest.Ops do
       assert Framestamp.add(a, b) == expected
     end
 
-    table_test "<%= a %> + <%= b %> == <%= expected %> | integer a", CommonTables.add_table(), test_case,
+    table_test "<%= a %> + <%= b %> == <%= expected %> | integer a", CommonTables.framestamp_add(), test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       a = Framestamp.frames(a)
@@ -291,7 +287,7 @@ defmodule Vtc.FramestampTest.Ops do
       assert Framestamp.add(a, b) == expected
     end
 
-    table_test "<%= a %> + <%= b %> == <%= expected %> | string b", CommonTables.add_table(), test_case,
+    table_test "<%= a %> + <%= b %> == <%= expected %> | string b", CommonTables.framestamp_add(), test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       b = Framestamp.smpte_timecode(b)
@@ -299,7 +295,7 @@ defmodule Vtc.FramestampTest.Ops do
       assert Framestamp.add(a, b) == expected
     end
 
-    table_test "<%= a %> + <%= b %> == <%= expected %> | string a", CommonTables.add_table(), test_case,
+    table_test "<%= a %> + <%= b %> == <%= expected %> | string a", CommonTables.framestamp_add(), test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       a = Framestamp.smpte_timecode(a)
@@ -426,12 +422,12 @@ defmodule Vtc.FramestampTest.Ops do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
-    table_test "<%= a %> - <%= b %> == <%= expected %>", CommonTables.subtract_table(), test_case do
+    table_test "<%= a %> - <%= b %> == <%= expected %>", CommonTables.framestamp_subtract(), test_case do
       %{a: a, b: b, expected: expected} = test_case
       assert Framestamp.sub(a, b) == expected
     end
 
-    table_test "<%= a %> - <%= b %> == <%= expected %> | integer b", CommonTables.subtract_table(), test_case,
+    table_test "<%= a %> - <%= b %> == <%= expected %> | integer b", CommonTables.framestamp_subtract(), test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       b = Framestamp.frames(b)
@@ -439,7 +435,7 @@ defmodule Vtc.FramestampTest.Ops do
       assert Framestamp.sub(a, b) == expected
     end
 
-    table_test "<%= a %> - <%= b %> == <%= expected %> | integer a", CommonTables.subtract_table(), test_case,
+    table_test "<%= a %> - <%= b %> == <%= expected %> | integer a", CommonTables.framestamp_subtract(), test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       a = Framestamp.frames(a)
@@ -447,7 +443,7 @@ defmodule Vtc.FramestampTest.Ops do
       assert Framestamp.sub(a, b) == expected
     end
 
-    table_test "<%= a %> - <%= b %> == <%= expected %> | string b", CommonTables.subtract_table(), test_case,
+    table_test "<%= a %> - <%= b %> == <%= expected %> | string b", CommonTables.framestamp_subtract(), test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       b = Framestamp.smpte_timecode(b)
@@ -455,7 +451,7 @@ defmodule Vtc.FramestampTest.Ops do
       assert Framestamp.sub(a, b) == expected
     end
 
-    table_test "<%= a %> - <%= b %> == <%= expected %> | string a", CommonTables.subtract_table(), test_case,
+    table_test "<%= a %> - <%= b %> == <%= expected %> | string a", CommonTables.framestamp_subtract(), test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, expected: expected} = test_case
       a = Framestamp.smpte_timecode(a)

--- a/test/support/common_tables.ex
+++ b/test/support/common_tables.ex
@@ -6,9 +6,9 @@ defmodule Vtc.Test.Support.CommonTables do
   @doc """
   Data for running tests on comparison operators.
   """
-  @spec compare_table() ::
+  @spec framestamp_compare() ::
           [%{a: TestCase.framestamp_input(), b: TestCase.framestamp_input(), expected: :eq | :lt | :gt}]
-  def compare_table do
+  def framestamp_compare do
     [
       %{
         a: "01:00:00:00",
@@ -146,9 +146,9 @@ defmodule Vtc.Test.Support.CommonTables do
   @doc """
   Data for running tests on addition operators.
   """
-  @spec add_table() ::
+  @spec framestamp_add() ::
           [%{a: TestCase.framestamp_input(), b: TestCase.framestamp_input(), expected: TestCase.framestamp_input()}]
-  def add_table do
+  def framestamp_add do
     [
       %{
         a: "01:00:00:00",
@@ -191,9 +191,9 @@ defmodule Vtc.Test.Support.CommonTables do
   @doc """
   Data for running tests on subtraction operators.
   """
-  @spec subtract_table() ::
+  @spec framestamp_subtract() ::
           [%{a: TestCase.framestamp_input(), b: TestCase.framestamp_input(), expected: TestCase.framestamp_input()}]
-  def subtract_table do
+  def framestamp_subtract do
     [
       %{
         a: "01:00:00:00",
@@ -231,5 +231,352 @@ defmodule Vtc.Test.Support.CommonTables do
         expected: {"01:00:00:01", Rates.f23_98()}
       }
     ]
+  end
+
+  @doc """
+  Test data for checking that a timecode range inclu
+  """
+  @spec range_contains() ::
+          [
+            %{
+              name: String.t(),
+              range: TestCase.range_shorthand(),
+              framestamp: TestCase.framestamp_input(),
+              expected: boolean(),
+              expected_negative: boolean()
+            }
+          ]
+  def range_contains do
+    [
+      %{
+        name: "range.in < stamp < range.out | :exclusive",
+        range: {"01:00:00:00", "02:00:00:00"},
+        framestamp: "01:30:00:00",
+        expected: true,
+        expected_negative: true
+      },
+      %{
+        name: "stamp == range.in | :exclusive",
+        range: {"01:00:00:00", "02:00:00:00"},
+        framestamp: "01:00:00:00",
+        expected: true,
+        expected_negative: false
+      },
+      %{
+        name: "stamp == range.out - 1 | :exclusive",
+        range: {"01:00:00:00", "02:00:00:00"},
+        framestamp: "01:59:59:23",
+        expected: true,
+        expected_negative: true
+      },
+      %{
+        name: "stamp == range.in - 1 | :exclusive",
+        range: {"01:00:00:00", "02:00:00:00"},
+        framestamp: "00:59:59:23",
+        expected: false,
+        expected_negative: false
+      },
+      %{
+        name: "stamp == range.out | :exclusive",
+        range: {"01:00:00:00", "02:00:00:00"},
+        framestamp: "02:00:00:00",
+        expected: false,
+        expected_negative: true
+      },
+      %{
+        name: "stamp < range.in | :exclusive",
+        range: {"01:00:00:00", "02:00:00:00"},
+        framestamp: "00:30:00:00",
+        expected: false,
+        expected_negative: false
+      },
+      %{
+        name: "stamp < range.in | sign flipped | :exclusive",
+        range: {"01:00:00:00", "02:00:00:00"},
+        framestamp: "-01:30:00:00",
+        expected: false,
+        expected_negative: false
+      },
+      %{
+        name: "stamp > range.out | :exclusive",
+        range: {"01:00:00:00", "02:00:00:00"},
+        framestamp: "02:30:00:00",
+        expected: false,
+        expected_negative: false
+      },
+      %{
+        name: "range.in < stamp < range.out | :inclusive",
+        range: {"01:00:00:00", "02:00:00:00", :inclusive},
+        framestamp: "01:30:00:00",
+        expected: true,
+        expected_negative: true
+      },
+      %{
+        name: "stamp == range.in | :inclusive",
+        range: {"01:00:00:00", "02:00:00:00", :inclusive},
+        framestamp: "01:00:00:00",
+        expected: true,
+        expected_negative: true
+      },
+      %{
+        name: "stamp == range.out - 1 | :inclusive",
+        range: {"01:00:00:00", "02:00:00:00", :inclusive},
+        framestamp: "01:59:59:23",
+        expected: true,
+        expected_negative: true
+      },
+      %{
+        name: "stamp == range.in - 1 | :inclusive",
+        range: {"01:00:00:00", "02:00:00:00", :inclusive},
+        framestamp: "00:59:59:23",
+        expected: false,
+        expected_negative: false
+      },
+      %{
+        name: "stamp == range.out | :inclusive",
+        range: {"01:00:00:00", "02:00:00:00", :inclusive},
+        framestamp: "02:00:00:00",
+        expected: true,
+        expected_negative: true
+      },
+      %{
+        name: "stamp == range.out + 1 | :inclusive",
+        range: {"01:00:00:00", "02:00:00:00", :inclusive},
+        framestamp: "02:00:00:01",
+        expected: false,
+        expected_negative: false
+      },
+      %{
+        name: "stamp < range.in | :inclusive",
+        range: {"01:00:00:00", "02:00:00:00", :inclusive},
+        framestamp: "00:30:00:00",
+        expected: false,
+        expected_negative: false
+      },
+      %{
+        name: "stamp < range.in | sign flipped | :inclusive",
+        range: {"01:00:00:00", "02:00:00:00", :inclusive},
+        framestamp: "-01:30:00:00",
+        expected: false,
+        expected_negative: false
+      },
+      %{
+        name: "stamp > range.out | :inclusive",
+        range: {"01:00:00:00", "02:00:00:00", :inclusive},
+        framestamp: "02:30:00:00",
+        expected: false,
+        expected_negative: false
+      }
+    ]
+  end
+
+  @doc """
+  Test data for checking if two timecode ranges overlap.
+  """
+  @spec range_overlaps() :: [
+          %{
+            name: String.t(),
+            a: TestCase.range_shorthand(),
+            b: TestCase.range_shorthand(),
+            expected: boolean()
+          }
+        ]
+  def range_overlaps do
+    base_cases = [
+      %{
+        name: "a.in == b.in and a.out == b.out",
+        a: {"01:00:00:00", "02:00:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: true
+      },
+      %{
+        name: "a.in == b.in and a.out < b.out",
+        a: {"01:00:00:00", "01:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: true
+      },
+      %{
+        name: "a.in == b.in and a.out > b.out",
+        a: {"01:00:00:00", "02:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: true
+      },
+      %{
+        name: "a.in < b.in and a.out == b.out",
+        a: {"00:30:00:00", "02:00:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: true
+      },
+      %{
+        name: "a.in < b.in and a.out < b.out",
+        a: {"00:30:00:00", "01:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: true
+      },
+      %{
+        name: "a.in < b.in and a.out > b.out",
+        a: {"00:30:00:00", "02:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: true
+      },
+      %{
+        name: "a.in > b.in and a.out == b.out",
+        a: {"01:30:00:00", "02:00:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: true
+      },
+      %{
+        name: "a.in > b.in and a.out < b.out",
+        a: {"01:15:00:00", "01:45:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: true
+      },
+      %{
+        name: "a.in > b.in and a.out > b.out",
+        a: {"01:30:00:00", "02:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: true
+      },
+      %{
+        name: "a < b",
+        a: {"00:00:00:00", "00:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: false
+      },
+      %{
+        name: "a > b",
+        a: {"02:30:00:00", "03:00:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: false
+      },
+      %{
+        name: "a.out & b.in at boundary",
+        a: {"01:00:00:00", "02:00:00:00"},
+        b: {"02:00:00:00", "03:00:00:00"},
+        expected: false
+      },
+      %{
+        name: "a.in & b.out at boundary",
+        a: {"03:00:00:00", "04:00:00:00"},
+        b: {"02:00:00:00", "03:00:00:00"},
+        expected: false
+      }
+    ]
+
+    mixed_rate =
+      Enum.map(base_cases, fn test_case ->
+        %{name: name, b: {b_in, b_out}} = test_case
+
+        test_case
+        |> Map.put(:b, {b_in, b_out, Rates.f47_95()})
+        |> Map.put(:name, name <> " | mixed rate")
+      end)
+
+    Enum.concat(base_cases, mixed_rate)
+  end
+
+  @doc """
+  Test data for checking if two timecode ranges intersect.
+  """
+  @spec range_intersection() :: [
+          %{
+            name: String.t(),
+            a: TestCase.range_shorthand(),
+            b: TestCase.range_shorthand(),
+            expected: TestCase.range_shorthand()
+          }
+        ]
+  def range_intersection do
+    base_cases = [
+      %{
+        name: "a.in == b.in and a.out == b.out",
+        a: {"01:00:00:00", "02:00:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: {"01:00:00:00", "02:00:00:00"}
+      },
+      %{
+        name: "a.in == b.in and a.out < b.out",
+        a: {"01:00:00:00", "01:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: {"01:00:00:00", "01:30:00:00"}
+      },
+      %{
+        name: "a.in == b.in and a.out > b.out",
+        a: {"01:00:00:00", "02:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: {"01:00:00:00", "02:00:00:00"}
+      },
+      %{
+        name: "a.in < b.in and a.out == b.out",
+        a: {"00:30:00:00", "02:00:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: {"01:00:00:00", "02:00:00:00"}
+      },
+      %{
+        name: "a.in < b.in and a.out < b.out",
+        a: {"00:30:00:00", "01:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: {"01:00:00:00", "01:30:00:00"}
+      },
+      %{
+        name: "a.in < b.in and a.out > b.out",
+        a: {"00:30:00:00", "02:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: {"01:00:00:00", "02:00:00:00"}
+      },
+      %{
+        name: "a.in > b.in and a.out == b.out",
+        a: {"01:30:00:00", "02:00:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: {"01:30:00:00", "02:00:00:00"}
+      },
+      %{
+        name: "a.in > b.in and a.out < b.out",
+        a: {"01:15:00:00", "01:45:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: {"01:15:00:00", "01:45:00:00"}
+      },
+      %{
+        name: "a.in > b.in and a.out > b.out",
+        a: {"01:30:00:00", "02:30:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: {"01:30:00:00", "02:00:00:00"}
+      },
+      %{
+        name: "a < b",
+        a: {"01:00:00:00", "02:00:00:00"},
+        b: {"03:00:00:00", "04:00:00:00"},
+        expected: {:error, :none}
+      },
+      %{
+        name: "a > b",
+        a: {"03:00:00:00", "04:00:00:00"},
+        b: {"01:00:00:00", "02:00:00:00"},
+        expected: {:error, :none}
+      },
+      %{
+        name: "a.out & b.in at boundary",
+        a: {"01:00:00:00", "02:00:00:00"},
+        b: {"02:00:00:00", "03:00:00:00"},
+        expected: {:error, :none}
+      },
+      %{
+        name: "a.in & b.out at boundary",
+        a: {"03:00:00:00", "04:00:00:00"},
+        b: {"02:00:00:00", "03:00:00:00"},
+        expected: {:error, :none}
+      }
+    ]
+
+    mixed_rate =
+      Enum.map(base_cases, fn test_case ->
+        %{name: name, b: {b_in, b_out}} = test_case
+
+        test_case
+        |> Map.put(:b, {b_in, b_out, Rates.f47_95()})
+        |> Map.put(:name, name <> " | mixed rate")
+      end)
+
+    Enum.concat(base_cases, mixed_rate)
   end
 end

--- a/test/support/framestamp_schema_02.ex
+++ b/test/support/framestamp_schema_02.ex
@@ -1,0 +1,25 @@
+defmodule Vtc.Test.Support.FramestampSchema02 do
+  @moduledoc """
+  Dummy schema for verifying the Postgres Repo in our test env
+  """
+  use Ecto.Schema
+
+  alias Ecto.Changeset
+  alias Vtc.Framestamp
+
+  @type t() :: %__MODULE__{
+          id: Ecto.UUID.t(),
+          a: Framestamp.t(),
+          b: Framestamp.t()
+        }
+
+  @primary_key {:id, Ecto.UUID, autogenerate: true}
+
+  schema "framestamps_02" do
+    field(:a, Framestamp)
+    field(:b, Framestamp)
+  end
+
+  @spec changeset(%__MODULE__{}, %{atom() => any()}) :: Changeset.t(%__MODULE__{})
+  def changeset(schema, attrs), do: Changeset.cast(schema, attrs, [:id, :a, :b])
+end


### PR DESCRIPTION
Creates a framestamp [Postgres range type](https://github.com/opencinemac/vtc-ex/pull/65).

There's some interesting things in this PR. For instance, but let's look at the impetus behind it. First: we need to have ranges handled by a type because you have to have a type to hang GiST indexes off of. GiSTs are built by supplying a type that implements a required set of operators. The nice thing about Ranges is that if their subtype implements all the BTree operators, you get the Range operators for free.

Second, there's an idea that Postgres has called 'canonicalization'. Basically, for ranges with discreet sub-values that don't line up with their numerical representation, you need to define a function that can nudge the in/out values of the range by one step. In our case, we need to be able to adjust the seconds value by a single frame. For instance, we need to nudge 23.98 ranges by `1001/24000` steps (the duration of a single frame).

Postgres uses this function to normalize ranges with inclusive/exclusive in/out semantics to a 'canonical' type, making them comparable. Some range functions need this ability. For instance, finding adjacent ranges (which could be used to find cut points in an EDL track).

That means that we need to package the framerate as part of the range type for all range operations to be sensical.

One insight I gained when writing this PR is that for comparison operations, we can use a range of double-precision floats and remain frame-accurate. Since we are always simplifying fractions at the end of an operation, we can guarantee that the same float will always be generated for the same rational seconds value. It's a benefit of using rational values in calculations that we can count on consistent float representations when needed for inspection... as long as we don't manipulate that float once cast, it will remain frame-accurate for doing things like finding overlapping events, even in mixed-frame settings.

This PR includes a second range type called `framestamp_fastrange`, which casts the in and out points to double precision floats (Postgres doesn't ship with a double precision range but it's the given example in their docs for custom ranges).

Surprisingly, when testing a query that finds overlapping ranges using an GiST index, the regular, rational-based `framestamp_range` is *just as fast* as `framestamp_fastrange`. On my MacBook, I could query for all overlaps in a set of 100,000 records in about 43ms. However, inserts for the `framestamp_range` are about 10x slower -- 65 seconds to insert those 100,000 records with an indexed rational range vs 6.5 seconds for the float version -- making the `framestamp_fastrange`  preferable when doing operations that don't need to adjust discreet frame values. Interestingly, Btree indexes don't have this problem, just GiST. You pay through the teeth on inserts when indexing the fully qualified Framestamp range, but you get float-like performance out of it.

I have to imagine that some of that slow-down is due to the operators being pl/pgSql functions, but Aurora doesn't offer anything better. Hopefully we'll eventually get access to pl/Rust like RDS has, and that would give us speeds comparable to native functions. I may write a version of all these functions in pl/Rust at some point and make the implementation configurable per-repo, but for now it's what we have.

There are some open questions for me about how ranges that combine ranges should work in mixed framerate settings. For instance: when getting the intersection of two ranges what framerate should be inherited? Normally Vtc's MO is to say that the framerate of the left value gets inherited, but for Ranges Postgres autogens most of the operators, so I don't have full control over that. I may decide to overload operators that yield a new Range, but I can push that decision until later.