### PR TITLE
[Refactor] Optimizations

### DIFF
--- a/lib/ecto/postgres/pg_utils.ex
+++ b/lib/ecto/postgres/pg_utils.ex
@@ -302,8 +302,8 @@ defmodule Vtc.Ecto.Postgres.Utils do
   @doc """
   Builds an SQL query for creating a new native CAST
   """
-  @spec create_cast(atom(), atom(), Macro.t()) :: Macro.t()
-  defmacro create_cast(left_type, right_type, func_name) do
+  @spec create_cast(atom(), atom(), Macro.t(), Macro.t()) :: Macro.t()
+  defmacro create_cast(left_type, right_type, func_name, opts \\ []) do
     quote do
       comment = unquote(__MODULE__).create_comment_string(__ENV__, :cast)
 
@@ -311,16 +311,21 @@ defmodule Vtc.Ecto.Postgres.Utils do
         unquote(left_type),
         unquote(right_type),
         unquote(func_name),
-        comment
+        comment,
+        unquote(opts)
       )
     end
   end
 
-  @spec create_cast_raw_sql(atom(), atom(), atom() | String.t(), String.t()) :: raw_sql()
-  def create_cast_raw_sql(left_type, right_type, func_name, comment) do
+  @spec create_cast_raw_sql(atom(), atom(), atom() | String.t(), String.t(), implicit: boolean()) :: raw_sql()
+  def create_cast_raw_sql(left_type, right_type, func_name, comment, opts) do
+    implicit = if Keyword.get(opts, :implicit, false), do: "AS IMPLICIT", else: ""
+
     """
     DO $wrapper$ BEGIN
-      CREATE CAST (#{left_type} AS #{right_type}) WITH FUNCTION #{func_name}(#{left_type});
+      CREATE CAST (#{left_type} AS #{right_type})
+      WITH FUNCTION #{func_name}(#{left_type})
+      #{implicit};
 
       COMMENT ON
       CAST (#{left_type} AS #{right_type})

--- a/test/ecto/postgres/pg_index_test.exs
+++ b/test/ecto/postgres/pg_index_test.exs
@@ -240,7 +240,6 @@ defmodule Vtc.Ecto.Postgres.PgRationalIndexTest do
         )
         |> Query.select([events_01: events_01, events_02: events_02], {events_01.id, events_02.id})
         |> then(&Repo.explain(:all, &1))
-        |> dbg()
 
       assert overlaps_plan =~ expected_plan_snippet
     end

--- a/test/ecto/postgres/pg_rational_test.exs
+++ b/test/ecto/postgres/pg_rational_test.exs
@@ -250,51 +250,6 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     end
   end
 
-  describe "#Postgres rational.__private__greatest_common_denominator/2" do
-    gcd_table = [
-      %{a: 2, b: 4, expected: 2},
-      %{a: 21, b: 14, expected: 7},
-      %{a: 23, b: 14, expected: 1},
-      %{a: 1000, b: 70, expected: 10}
-    ]
-
-    table_test "<%= a %>, <%= b %> == <%= expected %>", gcd_table, test_case do
-      %{a: a, b: b, expected: expected} = test_case
-
-      assert %Postgrex.Result{rows: rows} =
-               Repo.query!("SELECT rational.__private__greatest_common_denominator(#{a}, #{b})")
-
-      assert [[^expected]] = rows
-    end
-
-    table_test "-<%= a %>, <%= b %> == <%= expected %>", gcd_table, test_case do
-      %{a: a, b: b, expected: expected} = test_case
-
-      assert %Postgrex.Result{rows: rows} =
-               Repo.query!("SELECT rational.__private__greatest_common_denominator(-#{a}, #{b})")
-
-      assert [[^expected]] = rows
-    end
-
-    table_test "<%= a %>, -<%= b %> == <%= expected %>", gcd_table, test_case do
-      %{a: a, b: b, expected: expected} = test_case
-
-      assert %Postgrex.Result{rows: rows} =
-               Repo.query!("SELECT rational.__private__greatest_common_denominator(#{a}, -#{b})")
-
-      assert [[^expected]] = rows
-    end
-
-    table_test "-<%= a %>, -<%= b %> == <%= expected %>", gcd_table, test_case do
-      %{a: a, b: b, expected: expected} = test_case
-
-      assert %Postgrex.Result{rows: rows} =
-               Repo.query!("SELECT rational.__private__greatest_common_denominator(-#{a}, -#{b})")
-
-      assert [[^expected]] = rows
-    end
-  end
-
   describe "#Postgres rational.__private__simplify/1" do
     simplify_table = [
       %{numerator: 2, denominator: 4, expected: Ratio.new(1, 2)},


### PR DESCRIPTION
Miscellaneous optimizations:

- use native `gcd` in place of custom function. Lead to significant improvement on fraction simplifying
- use native `sign` to back `rational.cmp`
- native, implicit casting from `bigint` to `rational`. Cleans up some code that was building rationals from whole-number values

## Results

- When inserting 20,000 records with GiST indexes and constraints, time dropped from `22417.145 ms` to `12083.835 ms` (1.9x speedup)
- When summing 1,000,000 framestamp fields, time dropped from `5912.498 ms` to `2219.063 ms` (2.7x speedup)
- When comparing framestamp fields, time dropped from `1482.975 ms` to `1236.515 ms` (1.2x) speedup

## Verbose commands and results

### INSERTS (with constraints and GiST index)

```sql
INSERT INTO framestamps_02 (id, a, b)
SELECT 
    gen_random_uuid(),
    framestamp.with_seconds(
        (generate_series(1, 20000), 24), 
        ((24, 1), '{}')
    ),
    framestamp.with_seconds(
        (generate_series(20000, 40000), 24), 
        ((24, 1), '{}')
    )::framestamp;
```

#### BEFORE:

```text
INSERT 0 20001
Time: 22417.145 ms (00:22.417)
Time: 13013.513 ms (00:13.014)
Time: 19069.669 ms (00:19.070)
Time: 18800.046 ms (00:18.800)
```


#### AFTER

```text
INSERT 0 20001
Time: 12083.835 ms (00:12.084)
Time:  8063.852 ms (00:08.064)
Time:  7814.380 ms (00:07.814)
```

### Addition

```sql
INSERT INTO framestamps_01 (id, a, b)
SELECT 
    gen_random_uuid(),
    framestamp.with_frames(
        generate_series(1, 1000000), 
        ((24, 1), '{}')
    ),
    framestamp.with_frames(
        generate_series(1, 1000000),
        ((24, 1), '{}')
    )::framestamp;

EXPLAIN ANALYZE SELECT a + b FROM framestamps_01;
```

#### BEFORE

```text
 Gather  (cost=1000.00..693713.94 rows=3125025 width=32) (actual time=63.675..5877.839 rows=1000000 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on framestamps_01  (cost=0.00..380211.44 rows=1302094 width=32) (actual time=64.364..5741.625 rows=333333 loops=3)
 Planning Time: 0.267 ms
 JIT:
   Functions: 6
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 2.662 ms, Inlining 99.529 ms, Optimization 56.611 ms, Emission 33.106 ms, Total 191.908 ms
 Execution Time: 5912.498 ms
```

 #### AFTER

```text
  Gather  (cost=1000.00..693713.94 rows=3125025 width=32) (actual time=53.094..2184.971 rows=1000000 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on framestamps_01  (cost=0.00..380211.44 rows=1302094 width=32) (actual time=69.562..2045.049 rows=333333 loops=3)
 Planning Time: 0.910 ms
 JIT:
   Functions: 6
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 1.768 ms, Inlining 106.517 ms, Optimization 59.802 ms, Emission 34.690 ms, Total 202.777 ms
 Execution Time: 2219.063 ms
```

### Comparison

```sql
INSERT INTO framestamps_01 (id, a, b)
SELECT 
    gen_random_uuid(),
    framestamp.with_frames(
        generate_series(1, 1000000), 
        ((24, 1), '{}')
    ),
    framestamp.with_frames(
        generate_series(1, 1000000),
        ((24, 1), '{}')
    )::framestamp;

EXPLAIN ANALYZE SELECT a > b FROM framestamps_01;
```

#### BEFORE

```text
 Gather  (cost=1000.00..693713.94 rows=3125025 width=1) (actual time=63.890..1447.103 rows=1000000 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on framestamps_01  (cost=0.00..380211.44 rows=1302094 width=1) (actual time=76.736..1277.686 rows=333333 loops=3)
 Planning Time: 2.352 ms
 JIT:
   Functions: 6
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 3.416 ms, Inlining 109.668 ms, Optimization 70.699 ms, Emission 45.962 ms, Total 229.745 ms
 Execution Time: 1482.975 ms
```

#### AFTER

```text
 Gather  (cost=1000.00..693713.94 rows=3125025 width=1) (actual time=76.403..1203.029 rows=1000000 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on framestamps_01  (cost=0.00..380211.44 rows=1302094 width=1) (actual time=69.186..1046.817 rows=333333 loops=3)
 Planning Time: 1.526 ms
 JIT:
   Functions: 6
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 2.319 ms, Inlining 102.245 ms, Optimization 62.752 ms, Emission 37.440 ms, Total 204.755 ms
 Execution Time: 1236.515 ms
```
