### PR TITLE
[Bug] Fix default fetch of postgres type configs

### DIFF
--- a/lib/ecto/postgres/pg_utils.ex
+++ b/lib/ecto/postgres/pg_utils.ex
@@ -393,7 +393,7 @@ defmodule Vtc.Ecto.Postgres.Utils do
   """
   @spec get_type_config(Ecto.Repo.t(), atom(), atom(), Keyword.value()) :: Keyword.value()
   def get_type_config(repo, type_name, opt, default),
-    do: repo.config() |> Keyword.get(:vtc, []) |> Keyword.get(type_name) |> Keyword.get(opt, default)
+    do: repo.config() |> Keyword.get(:vtc, []) |> Keyword.get(type_name, []) |> Keyword.get(opt, default)
 
   @doc """
   Returns a the public function prefix for a specific vtc Postgres type and Repo.

--- a/lib/ecto/postgres/postgres_migrations.ex
+++ b/lib/ecto/postgres/postgres_migrations.ex
@@ -9,7 +9,6 @@ defpgmodule Vtc.Ecto.Postgres.Migrations do
   alias Vtc.Ecto.Postgres.PgFramestamp
   alias Vtc.Ecto.Postgres.PgRational
 
-  @spec migrate() :: :ok
   @doc """
   Runs all migrations. Safe to run multiple times when updates are required.
 
@@ -20,6 +19,7 @@ defpgmodule Vtc.Ecto.Postgres.Migrations do
   - [PgFramestamp](`Vtc.Ecto.Postgres.PgFramestamp.Migrations`)
   - [PgFramestamp.Range](`Vtc.Ecto.Postgres.PgFramestamp.Range.Migrations`)
   """
+  @spec migrate() :: :ok
   def migrate do
     PgRational.Migrations.create_all()
     PgFramerate.Migrations.create_all()


### PR DESCRIPTION
Left out default parameter for utility that fetches type configuration for native postgres types, so that when there was no Repo config for that type, an error occurred.

This PR fixes that bug.