### PR TITLE
[Bug] Allow keyword name fields in constraints

### DIFF
--- a/lib/ecto/postgres/pg_framestamp_migrations.ex
+++ b/lib/ecto/postgres/pg_framestamp_migrations.ex
@@ -935,14 +935,16 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   """
   @spec create_field_constraints(atom(), atom()) :: :ok
   def create_field_constraints(table, field) do
-    PgFramerate.Migrations.create_field_constraints(table, "(#{field}).rate", :"#{field}_rate")
+    sql_field = "#{table}.#{field}"
+
+    PgFramerate.Migrations.create_field_constraints(table, field, "(#{sql_field}).rate")
 
     seconds_divisible_by_rate =
       Migration.constraint(
         table,
         "#{field}_seconds_divisible_by_rate",
         check: """
-        ((#{field}).seconds * (#{field}).rate.playback) % 1::bigint = 0::bigint
+        ((#{sql_field}).seconds * (#{sql_field}).rate.playback) % 1::bigint = 0::bigint
         """
       )
 

--- a/lib/ecto/postgres/pg_rational_migrations.ex
+++ b/lib/ecto/postgres/pg_rational_migrations.ex
@@ -954,12 +954,14 @@ defpgmodule Vtc.Ecto.Postgres.PgRational.Migrations do
   """
   @spec create_field_constraints(atom(), atom()) :: :ok
   def create_field_constraints(table, field_name) do
+    sql_field = "#{table}.#{field_name}"
+
     constraint =
       Migration.constraint(
         table,
         "#{field_name}_denominator_positive",
         check: """
-        (#{field_name}).denominator > 0
+        (#{sql_field}).denominator > 0
         """
       )
 

--- a/priv/repo/migrations/20230712004908_keyword_field_name.exs
+++ b/priv/repo/migrations/20230712004908_keyword_field_name.exs
@@ -1,0 +1,39 @@
+defmodule Vtc.Test.Support.Repo.Migrations.KeywordFieldName do
+  @moduledoc false
+  use Ecto.Migration
+
+  alias Vtc.Ecto.Postgres.PgFramerate
+  alias Vtc.Ecto.Postgres.PgFramestamp
+  alias Vtc.Ecto.Postgres.PgRational
+  alias Vtc.Framerate
+  alias Vtc.Framestamp
+
+  def change do
+    create table("rational_keyword_fieldnames_constraints", primary_key: false) do
+      add(:id, :uuid, primary_key: true, null: false)
+      add(:in, PgRational.type())
+      add(:end, PgRational.type())
+    end
+
+    PgRational.Migrations.create_field_constraints("rational_keyword_fieldnames_constraints", :in)
+    PgRational.Migrations.create_field_constraints("rational_keyword_fieldnames_constraints", :end)
+
+    create table("framerate_keyword_fieldnames_constraints", primary_key: false) do
+      add(:id, :uuid, primary_key: true, null: false)
+      add(:in, Framerate.type())
+      add(:end, Framerate.type())
+    end
+
+    PgFramerate.Migrations.create_field_constraints("framerate_keyword_fieldnames_constraints", :in)
+    PgFramerate.Migrations.create_field_constraints("framerate_keyword_fieldnames_constraints", :end)
+
+    create table("framestamp_keyword_fieldnames_constraints", primary_key: false) do
+      add(:id, :uuid, primary_key: true, null: false)
+      add(:in, Framestamp.type())
+      add(:end, Framestamp.type())
+    end
+
+    PgFramestamp.Migrations.create_field_constraints("framestamp_keyword_fieldnames_constraints", :in)
+    PgFramestamp.Migrations.create_field_constraints("framestamp_keyword_fieldnames_constraints", :end)
+  end
+end

--- a/test/ecto/postgres/pg_framerate_test.exs
+++ b/test/ecto/postgres/pg_framerate_test.exs
@@ -346,28 +346,28 @@ defmodule Vtc.Ecto.Postgres.PgFramerateTest do
         value: "((-24000, 1001), '{non_drop}')",
         field: :b,
         expected_code: :check_violation,
-        expected_constraint: "b_positive"
+        expected_constraint: "b_rate_positive"
       },
       %{
         name: "zero",
         value: "((0, 1001), '{non_drop}')",
         field: :b,
         expected_code: :check_violation,
-        expected_constraint: "b_positive"
+        expected_constraint: "b_rate_positive"
       },
       %{
         name: "zero denominator",
         value: "((24, 0), '{}')",
         field: :b,
         expected_code: :check_violation,
-        expected_constraint: "b_positive"
+        expected_constraint: "b_rate_positive"
       },
       %{
         name: "negative denominator",
         value: "((24, -1), '{}')",
         field: :b,
         expected_code: :check_violation,
-        expected_constraint: "b_positive"
+        expected_constraint: "b_rate_positive"
       },
       %{
         name: "bad tag with constraints",

--- a/test/ecto/postgres/pg_framestamp_test.exs
+++ b/test/ecto/postgres/pg_framestamp_test.exs
@@ -404,21 +404,21 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
         value: "((0, 1), ((30000, 1001), '{drop, non_drop}'))",
         field: :b,
         expected_code: :check_violation,
-        expected_constraint: "b_rate_ntsc_tags"
+        expected_constraint: "b_ntsc_tags"
       },
       %{
         name: "framerate bad ntsc rate",
         value: "((1, 1), ((24, 1), '{non_drop}'))",
         field: :b,
         expected_code: :check_violation,
-        expected_constraint: "b_rate_ntsc_valid"
+        expected_constraint: "b_ntsc_valid"
       },
       %{
         name: "framerate bad drop rate",
         value: "((0, 1), ((24000, 1001), '{drop}'))",
         field: :b,
         expected_code: :check_violation,
-        expected_constraint: "b_rate_ntsc_drop_valid"
+        expected_constraint: "b_ntsc_drop_valid"
       },
       %{
         name: "framestamp bad seconds",


### PR DESCRIPTION
Fields in constraints must be table-qualified to avoid SQL syntax errors on fields that are also SQL keywords like `in` or `end`.