### PR TITLE
[Refactor] Remove "LEAKPROOF" function attribute

### DIFF
--- a/lib/ecto/postgres/pg_utils.ex
+++ b/lib/ecto/postgres/pg_utils.ex
@@ -160,7 +160,6 @@ defmodule Vtc.Ecto.Postgres.Utils do
         LANGUAGE plpgsql
         STRICT
         IMMUTABLE
-        LEAKPROOF
         PARALLEL SAFE
         #{cost_sql}
       AS $func$


### PR DESCRIPTION
Removes the `LEAKPROOF` attribute from pl/pgsql functions.

The `LEAKPROOF` value indicates that the function is safe to run even on tables with security barriers, but offers no suck benefits on other tables.

On RDS, creating a `LEAKPROOF` function requires superadmin privileges. As such, it will be easier to adopt this library if functions are not marked as such.

In the future, we should consider making LEAKPROOF configurable. 