### PR TITLE
[Refactor] Configurable framerate inheritance on add/sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ by adding `vtc` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:vtc, "~> 0.12"}
+    {:vtc, "~> 0.14"}
   ]
 end
 ```

--- a/lib/ecto/postgres/pg_framestamp.ex
+++ b/lib/ecto/postgres/pg_framestamp.ex
@@ -115,7 +115,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp do
 
   @doc section: :ecto_migrations
   @doc """
-  The database type for [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`).
+  The database type for [PgFramestamp](`Vtc.Ecto.Postgres.PgFramestamp`).
 
   Can be used in migrations as the fields type.
   """
@@ -128,8 +128,11 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp do
   """
   @type db_record() :: {PgRational.db_record(), PgFramerate.db_record()}
 
-  # Handles casting PgRational fields in `Ecto.Changeset`s.
-  @doc false
+  @doc """
+  The database type for [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`).
+
+  Can be used in migrations as the fields type.
+  """
   @impl Ecto.Type
   @spec cast(Framestamp.t() | %{String.t() => any()} | %{atom() => any()}) :: {:ok, Framerate.t()} | :error
   def cast(%Framestamp{} = framestamp), do: {:ok, framestamp}

--- a/lib/ecto/postgres/pg_framestamp_migrations.ex
+++ b/lib/ecto/postgres/pg_framestamp_migrations.ex
@@ -129,11 +129,11 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
       &create_func_gte/0,
       &create_func_cmp/0,
       &create_func_add/0,
-      &create_func_add_inheret_left/0,
-      &create_func_add_inheret_right/0,
+      &create_func_add_inherit_left/0,
+      &create_func_add_inherit_right/0,
       &create_func_sub/0,
-      &create_func_sub_inheret_left/0,
-      &create_func_sub_inheret_right/0,
+      &create_func_sub_inherit_left/0,
+      &create_func_sub_inherit_right/0,
       &create_func_mult_rational/0,
       &create_func_div_rational/0,
       &create_func_floor_div_rational/0,
@@ -147,11 +147,11 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
       &create_op_gt/0,
       &create_op_gte/0,
       &create_op_add/0,
-      &create_op_add_inheret_left/0,
-      &create_op_add_inheret_right/0,
+      &create_op_add_inherit_left/0,
+      &create_op_add_inherit_right/0,
       &create_op_sub/0,
-      &create_op_sub_inheret_left/0,
-      &create_op_sub_inheret_right/0,
+      &create_op_sub_inherit_left/0,
+      &create_op_sub_inherit_right/0,
       &create_op_mult_rational/0,
       &create_op_div_rational/0,
       &create_op_modulo_rational/0,
@@ -421,17 +421,17 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
 
   @doc section: :migrations_private_functions
   @doc """
-  Creates `framestamp.__private__add_inheret_lef(a, b)` that backs the `@+` operator.
+  Creates `framestamp.__private__add_inherit_lef(a, b)` that backs the `@+` operator.
 
-  If `a` and `b` do not have the same framerate, result will inheret `a`'s rate and
+  If `a` and `b` do not have the same framerate, result will inherit `a`'s rate and
   round seconsd to the nearest whole-frame.
   """
-  @spec create_func_add_inheret_left() :: {raw_sql(), raw_sql()}
-  def create_func_add_inheret_left do
+  @spec create_func_add_inherit_left() :: {raw_sql(), raw_sql()}
+  def create_func_add_inherit_left do
     with_seconds = function(:with_seconds, Migration.repo())
 
     Postgres.Utils.create_plpgsql_function(
-      private_function(:add_inheret_left, Migration.repo()),
+      private_function(:add_inherit_left, Migration.repo()),
       args: [a: :framestamp, b: :framestamp],
       declares: [seconds: {:rational, "(a).seconds + (b).seconds"}],
       returns: :framestamp,
@@ -447,17 +447,17 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
 
   @doc section: :migrations_private_functions
   @doc """
-  Creates `framestamp.__private__add_inheret_right(a, b)` that backs the `+@` operator.
+  Creates `framestamp.__private__add_inherit_right(a, b)` that backs the `+@` operator.
 
-  If `a` and `b` do not have the same framerate, result will inheret `b`'s rate and
+  If `a` and `b` do not have the same framerate, result will inherit `b`'s rate and
   round seconsd to the nearest whole-frame.
   """
-  @spec create_func_add_inheret_right() :: {raw_sql(), raw_sql()}
-  def create_func_add_inheret_right do
+  @spec create_func_add_inherit_right() :: {raw_sql(), raw_sql()}
+  def create_func_add_inherit_right do
     with_seconds = function(:with_seconds, Migration.repo())
 
     Postgres.Utils.create_plpgsql_function(
-      private_function(:add_inheret_right, Migration.repo()),
+      private_function(:add_inherit_right, Migration.repo()),
       args: [a: :framestamp, b: :framestamp],
       declares: [seconds: {:rational, "(a).seconds + (b).seconds"}],
       returns: :framestamp,
@@ -496,17 +496,17 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
 
   @doc section: :migrations_private_functions
   @doc """
-  Creates `framestamp.__private__sub_inheret_left(a, b)` that backs the `@-` operator.
+  Creates `framestamp.__private__sub_inherit_left(a, b)` that backs the `@-` operator.
 
-  If `a` and `b` do not have the same framerate, result will inheret `a`'s rate and
+  If `a` and `b` do not have the same framerate, result will inherit `a`'s rate and
   round seconsd to the nearest whole-frame.
   """
-  @spec create_func_sub_inheret_left() :: {raw_sql(), raw_sql()}
-  def create_func_sub_inheret_left do
+  @spec create_func_sub_inherit_left() :: {raw_sql(), raw_sql()}
+  def create_func_sub_inherit_left do
     with_seconds = function(:with_seconds, Migration.repo())
 
     Postgres.Utils.create_plpgsql_function(
-      private_function(:sub_inheret_left, Migration.repo()),
+      private_function(:sub_inherit_left, Migration.repo()),
       args: [a: :framestamp, b: :framestamp],
       declares: [seconds: {:rational, "(a).seconds - (b).seconds"}],
       returns: :framestamp,
@@ -522,17 +522,17 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
 
   @doc section: :migrations_private_functions
   @doc """
-  Creates `framestamp.__private__sub_inheret_right(a, b)` that backs the `-@` operator.
+  Creates `framestamp.__private__sub_inherit_right(a, b)` that backs the `-@` operator.
 
-  If `a` and `b` do not have the same framerate, result will inheret `b`'s rate and
+  If `a` and `b` do not have the same framerate, result will inherit `b`'s rate and
   round seconsd to the nearest whole-frame.
   """
-  @spec create_func_sub_inheret_right() :: {raw_sql(), raw_sql()}
-  def create_func_sub_inheret_right do
+  @spec create_func_sub_inherit_right() :: {raw_sql(), raw_sql()}
+  def create_func_sub_inherit_right do
     with_seconds = function(:with_seconds, Migration.repo())
 
     Postgres.Utils.create_plpgsql_function(
-      private_function(:sub_inheret_right, Migration.repo()),
+      private_function(:sub_inherit_right, Migration.repo()),
       args: [a: :framestamp, b: :framestamp],
       declares: [seconds: {:rational, "(a).seconds - (b).seconds"}],
       returns: :framestamp,
@@ -825,16 +825,16 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :framestamp `@+` operator.
 
-  If `a` and `b` do not have the same framerate, result will inheret `a`'s rate and
+  If `a` and `b` do not have the same framerate, result will inherit `a`'s rate and
   round seconsd to the nearest whole-frame.
   """
-  @spec create_op_add_inheret_left() :: {raw_sql(), raw_sql()}
-  def create_op_add_inheret_left do
+  @spec create_op_add_inherit_left() :: {raw_sql(), raw_sql()}
+  def create_op_add_inherit_left do
     Postgres.Utils.create_operator(
       :"@+",
       :framestamp,
       :framestamp,
-      private_function(:add_inheret_left, Migration.repo()),
+      private_function(:add_inherit_left, Migration.repo()),
       commutator: :"+@"
     )
   end
@@ -843,16 +843,16 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :framestamp `+@` operator.
 
-  If `a` and `b` do not have the same framerate, result will inheret `b`'s rate and
+  If `a` and `b` do not have the same framerate, result will inherit `b`'s rate and
   round seconsd to the nearest whole-frame.
   """
-  @spec create_op_add_inheret_right() :: {raw_sql(), raw_sql()}
-  def create_op_add_inheret_right do
+  @spec create_op_add_inherit_right() :: {raw_sql(), raw_sql()}
+  def create_op_add_inherit_right do
     Postgres.Utils.create_operator(
       :"+@",
       :framestamp,
       :framestamp,
-      private_function(:add_inheret_right, Migration.repo()),
+      private_function(:add_inherit_right, Migration.repo()),
       commutator: :"@+"
     )
   end
@@ -862,7 +862,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   Creates a custom :framestamp, :framestamp `-` operator.
 
   Just like [Framestamp.add/3](`Vtc.Framestamp.sub/3`), if the `rate` of `a` and `b`
-  are not equal, the result will inheret `a`'s framerate, and the internal `seconds`
+  are not equal, the result will inherit `a`'s framerate, and the internal `seconds`
   field will be rounded to the nearest whole-frame to ensure data integrity.
   """
   @spec create_op_sub() :: {raw_sql(), raw_sql()}
@@ -879,16 +879,16 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :framestamp `@-` operator.
 
-  If `a` and `b` do not have the same framerate, result will inheret `a`'s rate and
+  If `a` and `b` do not have the same framerate, result will inherit `a`'s rate and
   round seconsd to the nearest whole-frame.
   """
-  @spec create_op_sub_inheret_left() :: {raw_sql(), raw_sql()}
-  def create_op_sub_inheret_left do
+  @spec create_op_sub_inherit_left() :: {raw_sql(), raw_sql()}
+  def create_op_sub_inherit_left do
     Postgres.Utils.create_operator(
       :"@-",
       :framestamp,
       :framestamp,
-      private_function(:sub_inheret_left, Migration.repo())
+      private_function(:sub_inherit_left, Migration.repo())
     )
   end
 
@@ -896,16 +896,16 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :framestamp `-@` operator.
 
-  If `a` and `b` do not have the same framerate, result will inheret `b`'s rate and
+  If `a` and `b` do not have the same framerate, result will inherit `b`'s rate and
   round seconsd to the nearest whole-frame.
   """
-  @spec create_op_sub_inheret_right() :: {raw_sql(), raw_sql()}
-  def create_op_sub_inheret_right do
+  @spec create_op_sub_inherit_right() :: {raw_sql(), raw_sql()}
+  def create_op_sub_inherit_right do
     Postgres.Utils.create_operator(
       :"-@",
       :framestamp,
       :framestamp,
-      private_function(:sub_inheret_right, Migration.repo())
+      private_function(:sub_inherit_right, Migration.repo())
     )
   end
 

--- a/lib/ecto/postgres/pg_framestamp_migrations.ex
+++ b/lib/ecto/postgres/pg_framestamp_migrations.ex
@@ -400,7 +400,9 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates `framestamp.__private__add(a, b)` that backs the `+` operator.
 
-  Raises exception if `a` and `b` do not have the same framerate.
+  Adds `a` to `b`.
+
+  **raises**: `data_exception` if `a` and `b` do not have the same framerate.
   """
   @spec create_func_add() :: {raw_sql(), raw_sql()}
   def create_func_add do
@@ -423,8 +425,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates `framestamp.__private__add_inherit_lef(a, b)` that backs the `@+` operator.
 
-  If `a` and `b` do not have the same framerate, result will inherit `a`'s rate and
-  round seconsd to the nearest whole-frame.
+  Adds `a` to `b`. If `a` and `b` do not have the same framerate, result will inherit
+  `a`'s rate and round seconds to the nearest whole-frame.
   """
   @spec create_func_add_inherit_left() :: {raw_sql(), raw_sql()}
   def create_func_add_inherit_left do
@@ -449,8 +451,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates `framestamp.__private__add_inherit_right(a, b)` that backs the `+@` operator.
 
-  If `a` and `b` do not have the same framerate, result will inherit `b`'s rate and
-  round seconsd to the nearest whole-frame.
+  Adds `a` to `b`. If `a` and `b` do not have the same framerate, result will inherit
+  `b`'s rate and round seconds to the nearest whole-frame.
   """
   @spec create_func_add_inherit_right() :: {raw_sql(), raw_sql()}
   def create_func_add_inherit_right do
@@ -475,7 +477,9 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   `framestamp.__private__sub(a, b)` that backs the `-` operator.
 
-  Raises exception if `a` and `b` do not have the same framerate.
+  Subtracts `a` from `b`.
+
+  **raises**: `data_exception` if `a` and `b` do not have the same framerate.
   """
   @spec create_func_sub() :: {raw_sql(), raw_sql()}
   def create_func_sub do
@@ -498,8 +502,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates `framestamp.__private__sub_inherit_left(a, b)` that backs the `@-` operator.
 
-  If `a` and `b` do not have the same framerate, result will inherit `a`'s rate and
-  round seconsd to the nearest whole-frame.
+  Subtracts `a` from `b`. If `a` and `b` do not have the same framerate, result will
+  inherit `a`'s rate and round seconds to the nearest whole-frame.
   """
   @spec create_func_sub_inherit_left() :: {raw_sql(), raw_sql()}
   def create_func_sub_inherit_left do
@@ -524,8 +528,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates `framestamp.__private__sub_inherit_right(a, b)` that backs the `-@` operator.
 
-  If `a` and `b` do not have the same framerate, result will inherit `b`'s rate and
-  round seconsd to the nearest whole-frame.
+  Subtracts `a` from `b`. If `a` and `b` do not have the same framerate, result will
+  inherit `b`'s rate and round seconds to the nearest whole-frame.
   """
   @spec create_func_sub_inherit_right() :: {raw_sql(), raw_sql()}
   def create_func_sub_inherit_right do
@@ -565,7 +569,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates `framestamp.__private__mult(:framestamp, :rational)` that backs the `*` operator.
 
-  Just like [Framestamp.add/3](`Vtc.Framestamp.mult/3`), `a`'s the internal `seconds`
+  Just like [Framestamp.mult/3](`Vtc.Framestamp.mult/3`), `a`'s the internal `seconds`
   field will be rounded to the nearest whole-frame to ensure data integrity.
   """
   @spec create_func_mult_rational() :: {raw_sql(), raw_sql()}
@@ -808,7 +812,9 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :framestamp `+` operator.
 
-  Raises exception if `a` and `b` do not have the same framerate.
+  Adds `a` to `b`.
+
+  **raises**: `data_exception` if `a` and `b` do not have the same framerate.
   """
   @spec create_op_add() :: {raw_sql(), raw_sql()}
   def create_op_add do
@@ -825,8 +831,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :framestamp `@+` operator.
 
-  If `a` and `b` do not have the same framerate, result will inherit `a`'s rate and
-  round seconsd to the nearest whole-frame.
+  Adds `a` to `b`. If `a` and `b` do not have the same framerate, result will inherit
+  `a`'s rate and round seconds to the nearest whole-frame.
   """
   @spec create_op_add_inherit_left() :: {raw_sql(), raw_sql()}
   def create_op_add_inherit_left do
@@ -843,8 +849,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :framestamp `+@` operator.
 
-  If `a` and `b` do not have the same framerate, result will inherit `b`'s rate and
-  round seconsd to the nearest whole-frame.
+  Adds `a` to `b`. If `a` and `b` do not have the same framerate, result will inherit
+  `b`'s rate and round seconds to the nearest whole-frame.
   """
   @spec create_op_add_inherit_right() :: {raw_sql(), raw_sql()}
   def create_op_add_inherit_right do
@@ -861,9 +867,9 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :framestamp `-` operator.
 
-  Just like [Framestamp.add/3](`Vtc.Framestamp.sub/3`), if the `rate` of `a` and `b`
-  are not equal, the result will inherit `a`'s framerate, and the internal `seconds`
-  field will be rounded to the nearest whole-frame to ensure data integrity.
+  Subtracts `a` from `b`.
+
+  **raises**: `data_exception` if `a` and `b` do not have the same framerate.
   """
   @spec create_op_sub() :: {raw_sql(), raw_sql()}
   def create_op_sub do
@@ -879,8 +885,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :framestamp `@-` operator.
 
-  If `a` and `b` do not have the same framerate, result will inherit `a`'s rate and
-  round seconsd to the nearest whole-frame.
+  Subtracts `a` from `b`. If `a` and `b` do not have the same framerate, result will
+  inherit `a`'s rate and round seconds to the nearest whole-frame.
   """
   @spec create_op_sub_inherit_left() :: {raw_sql(), raw_sql()}
   def create_op_sub_inherit_left do
@@ -896,8 +902,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :framestamp `-@` operator.
 
-  If `a` and `b` do not have the same framerate, result will inherit `b`'s rate and
-  round seconsd to the nearest whole-frame.
+  Subtracts `a` from `b`. If `a` and `b` do not have the same framerate, result will
+  inherit `b`'s rate and round seconds to the nearest whole-frame.
   """
   @spec create_op_sub_inherit_right() :: {raw_sql(), raw_sql()}
   def create_op_sub_inherit_right do
@@ -913,8 +919,8 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   @doc """
   Creates a custom :framestamp, :rational `*` operator.
 
-  Just like [Framestamp.add/3](`Vtc.Framestamp.mult/3`), `a`'s the internal `seconds`
-  field will be rounded to the nearest whole-frame to ensure data integrity.
+  Just like [Framestamp.mult/3](`Vtc.Framestamp.mult/3`), `a`'s the internal `seconds`
+  value will be rounded to the nearest whole-frame to ensure data integrity.
   """
   @spec create_op_mult_rational() :: {raw_sql(), raw_sql()}
   def create_op_mult_rational do
@@ -931,7 +937,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Migrations do
   Creates a custom :framestamp, :rational `/` operator.
 
   Just like [Framestamp.div/3](`Vtc.Framestamp.div/3`), `a`'s the internal `seconds`
-  field will be rounded to the nearest whole-frame to ensure data integrity.
+  value will be rounded to the nearest whole-frame to ensure data integrity.
 
   Unlike [Framestamp.div/3](`Vtc.Framestamp.div/3`), the result is rounded to the
   *closest* frame, rather than truncating ala integer division.

--- a/lib/ecto/postgres/pg_framestamp_range.ex
+++ b/lib/ecto/postgres/pg_framestamp_range.ex
@@ -43,7 +43,7 @@ defpgmodule Vtc.Ecto.Postgres.PgFramestamp.Range do
   Further, when a Range operation, like a union, would result in an in and out point
   with different framerates, the higher rate will always be selected.
 
-  This unlike the application behavior of `Vtc.Framestamp.Range`, which always inherets
+  This unlike the application behavior of `Vtc.Framestamp.Range`, which always inherits
   the rate of the value that apears on the left side. This behavior may be updated to
   match Vtc's application behavior in the future.
 

--- a/lib/framerate.ex
+++ b/lib/framerate.ex
@@ -180,7 +180,7 @@ defmodule Vtc.Framerate do
     end
   end
 
-  @zero Ratio.new(0, 1)
+  @zero Ratio.new(0)
 
   @spec validate_positive(Ratio.t()) :: :ok | {:error, ParseError.t()}
   defp validate_positive(rate) do

--- a/lib/framerate.ex
+++ b/lib/framerate.ex
@@ -241,6 +241,12 @@ defmodule Vtc.Framerate do
   when_pg_enabled do
     use Ecto.Type
 
+    @doc section: :ecto_migrations
+    @doc """
+    The database type for [PgFramerate](`Vtc.Ecto.Postgres.PgFramerate`).
+
+    Can be used in migrations as the fields type.
+    """
     @impl Ecto.Type
     @spec type() :: atom()
     defdelegate type, to: PgFramerate

--- a/lib/framestamp.ex
+++ b/lib/framestamp.ex
@@ -1507,6 +1507,8 @@ defmodule Vtc.Framestamp do
   when_pg_enabled do
     use Ecto.Type
 
+    alias Ecto.Changeset
+
     @doc section: :ecto_migrations
     @doc """
     The database type for [PgFramestamp](`Vtc.Ecto.Postgres.PgFramestamp`).
@@ -1540,7 +1542,11 @@ defmodule Vtc.Framestamp do
     Pass the same options that were passed to
     [PgFramestamp.Migrations.create_constraints/3](`Vtc.Ecto.Postgres.PgFramestamp.Migrations.create_constraints/3`)
     """
-    @spec validate_constraints(Changeset.t(data), atom(), [PgFramestamp.Migrations.constraint_opt()]) :: Changeset.t(data)
+    @spec validate_constraints(
+            Changeset.t(data),
+            atom(),
+            [PgFramestamp.Migrations.constraint_opt()]
+          ) :: Changeset.t(data)
           when data: any()
     defdelegate validate_constraints(changeset, field, opts \\ []), to: PgFramestamp
   end

--- a/lib/framestamp.ex
+++ b/lib/framestamp.ex
@@ -1507,6 +1507,12 @@ defmodule Vtc.Framestamp do
   when_pg_enabled do
     use Ecto.Type
 
+    @doc section: :ecto_migrations
+    @doc """
+    The database type for [PgFramestamp](`Vtc.Ecto.Postgres.PgFramestamp`).
+
+    Can be used in migrations as the fields type.
+    """
     @impl Ecto.Type
     @spec type() :: atom()
     defdelegate type, to: PgFramestamp
@@ -1523,6 +1529,19 @@ defmodule Vtc.Framestamp do
     @spec dump(t()) :: {:ok, PgFramestamp.db_record()} | :error
     defdelegate dump(value), to: PgFramestamp
 
+    @doc section: :changeset_validators
+    @doc """
+    Adds all constraints created by
+    [PgFramestamp.Migrations.create_constraints/3](`Vtc.Ecto.Postgres.PgFramestamp.Migrations.create_constraints/3`)
+    to changeset to be added as changeset errors rather than raised.
+
+    ## Options
+
+    Pass the same options that were passed to
+    [PgFramestamp.Migrations.create_constraints/3](`Vtc.Ecto.Postgres.PgFramestamp.Migrations.create_constraints/3`)
+    """
+    @spec validate_constraints(Changeset.t(data), atom(), [PgFramestamp.Migrations.constraint_opt()]) :: Changeset.t(data)
+          when data: any()
     defdelegate validate_constraints(changeset, field, opts \\ []), to: PgFramestamp
   end
 end

--- a/lib/framestamp.ex
+++ b/lib/framestamp.ex
@@ -702,6 +702,7 @@ defmodule Vtc.Framestamp do
 
   Two framestamps running at different rates:
 
+  ```elixir
   iex> a = Framestamp.with_frames!("01:00:00:02", Rates.f23_98())
   iex> b = Framestamp.with_frames!("00:00:00:02", Rates.f47_95())
   iex>
@@ -712,6 +713,7 @@ defmodule Vtc.Framestamp do
   iex> result = Framestamp.add(a, b, inherit_rate: :right)
   iex> inspect(result)
   "<01:00:00:06 <47.95 NTSC>>"
+  ```
 
   If `:inherit_rate` is not set...
 
@@ -771,17 +773,6 @@ defmodule Vtc.Framestamp do
   "<00:30:21:17 <23.98 NTSC>>"
   ```
 
-  When `b` is greater than `a`, the result is negative:
-
-  ```elixir
-  iex> a = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
-  iex> b = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
-  iex>
-  iex> result = Framestamp.sub(a, b)
-  iex> inspect(result)
-  "<-01:00:00:00 <23.98 NTSC>>"
-  ```
-
   Two framestamps running at different rates:
 
   ```elixir
@@ -804,6 +795,17 @@ defmodule Vtc.Framestamp do
   iex> b = Framestamp.with_frames!("00:00:00:02", Rates.f47_95())
   iex> Framestamp.sub(a, b)
   ** (Vtc.Framestamp.MixedRateArithmaticError) attempted `Framestamp.sub(a, b)` where `a.rate` does not match `b.rate`. try `:inherit_rate` option to `:left` or `:right`. alternatively, do your calculation in seconds, then cast back to `Framestamp` with the appropriate rate
+  ```
+
+  When `b` is greater than `a`, the result is negative:
+
+  ```elixir
+  iex> a = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
+  iex> b = Framestamp.with_frames!("02:00:00:00", Rates.f23_98())
+  iex>
+  iex> result = Framestamp.sub(a, b)
+  iex> inspect(result)
+  "<-01:00:00:00 <23.98 NTSC>>"
   ```
 
   Using a framestamps and a bare string:

--- a/lib/framestamp.ex
+++ b/lib/framestamp.ex
@@ -285,9 +285,9 @@ defmodule Vtc.Framestamp do
   @type round() :: :closest | :floor | :ceil | :trunc | :off
 
   @typedoc """
-  Describes which side to inheret the framerate from in mixed-rate arithmatic.
+  Describes which side to inherit the framerate from in mixed-rate arithmatic.
   """
-  @type inheret_rate_opt() :: :left | :right | false
+  @type inherit_rate_opt() :: :left | :right | false
 
   @typedoc """
   Type returned by `with_seconds/3` and `with_frames/3`.
@@ -673,14 +673,14 @@ defmodule Vtc.Framestamp do
   Add two framestamps.
 
   Uses the real-world seconds representation. When the rates of `a` and `b` are not
-  equal, the result will inheret the framerate of `a` and be rounded to the seconds
+  equal, the result will inherit the framerate of `a` and be rounded to the seconds
   representation of the nearest whole-frame at that rate.
 
   [auto-casts](#module-artithmatic-autocasting) [Frames](`Vtc.Source.Frames`) values.
 
   ## Options
 
-  - `inheret_rate`: Which side to inheret the framerate from in mixed-rate calculations.
+  - `inherit_rate`: Which side to inherit the framerate from in mixed-rate calculations.
     If `false`, this function will raise if `a.rate` does not match `b.rate`.
     Default: `false`.
 
@@ -705,21 +705,21 @@ defmodule Vtc.Framestamp do
   iex> a = Framestamp.with_frames!("01:00:00:02", Rates.f23_98())
   iex> b = Framestamp.with_frames!("00:00:00:02", Rates.f47_95())
   iex>
-  iex> result = Framestamp.add(a, b, inheret_rate: :left)
+  iex> result = Framestamp.add(a, b, inherit_rate: :left)
   iex> inspect(result)
   "<01:00:00:03 <23.98 NTSC>>"
   iex>
-  iex> result = Framestamp.add(a, b, inheret_rate: :right)
+  iex> result = Framestamp.add(a, b, inherit_rate: :right)
   iex> inspect(result)
   "<01:00:00:06 <47.95 NTSC>>"
 
-  If `:inheret_rate` is not set...
+  If `:inherit_rate` is not set...
 
   ```elixir
   iex> a = Framestamp.with_frames!("01:00:00:02", Rates.f23_98())
   iex> b = Framestamp.with_frames!("00:00:00:02", Rates.f47_95())
   iex> Framestamp.add(a, b)
-  ** (Vtc.Framestamp.MixedRateArithmaticError) attempted `Framestamp.add(a, b)` where `a.rate` does not match `b.rate`. try `:inheret_rate` option to `:left` or `:right`. alternatively, do your calculation in seconds, then cast back to `Framestamp` with the appropriate rate
+  ** (Vtc.Framestamp.MixedRateArithmaticError) attempted `Framestamp.add(a, b)` where `a.rate` does not match `b.rate`. try `:inherit_rate` option to `:left` or `:right`. alternatively, do your calculation in seconds, then cast back to `Framestamp` with the appropriate rate
   ```
 
   Using a framestamps and a bare string:
@@ -735,7 +735,7 @@ defmodule Vtc.Framestamp do
   @spec add(
           a :: t() | Frames.t(),
           b :: t() | Frames.t(),
-          opts :: [inheret_rate: inheret_rate_opt(), round: round()]
+          opts :: [inherit_rate: inherit_rate_opt(), round: round()]
         ) :: t()
   def add(a, b, opts \\ []), do: do_arithmatic(a, b, :add, opts, &Ratio.add(&1, &2))
 
@@ -744,14 +744,14 @@ defmodule Vtc.Framestamp do
   Subtract `b` from `a`.
 
   Uses their real-world seconds representation. When the rates of `a` and `b` are not
-  equal, the result will inheret the framerate of `a` and be rounded to the seconds
+  equal, the result will inherit the framerate of `a` and be rounded to the seconds
   representation of the nearest whole-frame at that rate.
 
   [auto-casts](#module-artithmatic-autocasting) [Frames](`Vtc.Source.Frames`) values.
 
   ## Options
 
-  - `inheret_rate`: Which side to inheret the framerate from in mixed-rate calculations.
+  - `inherit_rate`: Which side to inherit the framerate from in mixed-rate calculations.
     If `false`, this function will raise if `a.rate` does not match `b.rate`.
     Default: `false`.
 
@@ -788,22 +788,22 @@ defmodule Vtc.Framestamp do
   iex> a = Framestamp.with_frames!("01:00:00:02", Rates.f23_98())
   iex> b = Framestamp.with_frames!("00:00:00:02", Rates.f47_95())
   iex>
-  iex> result = Framestamp.sub(a, b, inheret_rate: :left)
+  iex> result = Framestamp.sub(a, b, inherit_rate: :left)
   iex> inspect(result)
   "<01:00:00:01 <23.98 NTSC>>"
   iex>
-  iex> result = Framestamp.sub(a, b, inheret_rate: :right)
+  iex> result = Framestamp.sub(a, b, inherit_rate: :right)
   iex> inspect(result)
   "<01:00:00:02 <47.95 NTSC>>"
   ```
 
-  If `:inheret_rate` is not set...
+  If `:inherit_rate` is not set...
 
   ```elixir
   iex> a = Framestamp.with_frames!("01:00:00:02", Rates.f23_98())
   iex> b = Framestamp.with_frames!("00:00:00:02", Rates.f47_95())
   iex> Framestamp.sub(a, b)
-  ** (Vtc.Framestamp.MixedRateArithmaticError) attempted `Framestamp.sub(a, b)` where `a.rate` does not match `b.rate`. try `:inheret_rate` option to `:left` or `:right`. alternatively, do your calculation in seconds, then cast back to `Framestamp` with the appropriate rate
+  ** (Vtc.Framestamp.MixedRateArithmaticError) attempted `Framestamp.sub(a, b)` where `a.rate` does not match `b.rate`. try `:inherit_rate` option to `:left` or `:right`. alternatively, do your calculation in seconds, then cast back to `Framestamp` with the appropriate rate
   ```
 
   Using a framestamps and a bare string:
@@ -819,7 +819,7 @@ defmodule Vtc.Framestamp do
   @spec sub(
           a :: t() | Frames.t(),
           b :: t() | Frames.t(),
-          opts :: [inheret_rate: inheret_rate_opt(), round: round()]
+          opts :: [inherit_rate: inherit_rate_opt(), round: round()]
         ) :: t()
   def sub(a, b, opts \\ []), do: do_arithmatic(a, b, :sub, opts, &Ratio.sub(&1, &2))
 
@@ -828,16 +828,16 @@ defmodule Vtc.Framestamp do
           a :: t() | Frames.t(),
           b :: t() | Frames.t(),
           func_name :: :add | :sub,
-          opts :: [inheret_rate: inheret_rate_opt(), round: round()],
+          opts :: [inherit_rate: inherit_rate_opt(), round: round()],
           (Ratio.t(), Ratio.t() -> Ratio.t())
         ) :: t()
   defp do_arithmatic(a, b, func_name, opts, seconds_operation) do
-    inheret_rate = Keyword.get(opts, :inheret_rate, false)
+    inherit_rate = Keyword.get(opts, :inherit_rate, false)
 
-    case do_arithmatic_validate_rates(a, b, inheret_rate, func_name) do
+    case do_arithmatic_validate_rates(a, b, inherit_rate, func_name) do
       :ok ->
         {a, b} = cast_op_args(a, b)
-        new_rate = if inheret_rate == :left, do: a.rate, else: b.rate
+        new_rate = if inherit_rate == :left, do: a.rate, else: b.rate
 
         a.seconds
         |> seconds_operation.(b.seconds)
@@ -848,7 +848,7 @@ defmodule Vtc.Framestamp do
     end
   end
 
-  @spec do_arithmatic_validate_rates(t() | Frames.t(), t() | Frames.t(), inheret_rate_opt(), :add | :sub) ::
+  @spec do_arithmatic_validate_rates(t() | Frames.t(), t() | Frames.t(), inherit_rate_opt(), :add | :sub) ::
           :ok | {:error, MixedRateArithmaticError.t()}
   defp do_arithmatic_validate_rates(%Framestamp{rate: rate}, %Framestamp{rate: rate}, _, _), do: :ok
   defp do_arithmatic_validate_rates(_, _, :left, _), do: :ok
@@ -871,7 +871,7 @@ defmodule Vtc.Framestamp do
   @doc """
   Scales `a` by `b`.
 
-  The result will inheret the framerate of `a` and be rounded to the seconds
+  The result will inherit the framerate of `a` and be rounded to the seconds
   representation of the nearest whole-frame based on the `:round` option.
 
   ## Options

--- a/lib/framestamp_mixed_rate_arithmatic_error.ex
+++ b/lib/framestamp_mixed_rate_arithmatic_error.ex
@@ -1,7 +1,7 @@
 defmodule Vtc.Framestamp.MixedRateArithmaticError do
   @moduledoc """
   Exception returned when mixed-rate arithmatic was attempted without specifying which
-  side of the operation's rate should be inhereted.
+  side of the operation's rate should be inherited.
 
   ## Struct Fields
 
@@ -30,7 +30,7 @@ defmodule Vtc.Framestamp.MixedRateArithmaticError do
   @spec message(t()) :: String.t()
   def message(error) do
     "attempted `Framestamp.#{error.func_name}(a, b)` where `a.rate` does not match" <>
-      " `b.rate`. try `:inheret_rate` option to `:left` or `:right`." <>
+      " `b.rate`. try `:inherit_rate` option to `:left` or `:right`." <>
       " alternatively, do your calculation in seconds, then cast back to `Framestamp`" <>
       " with the appropriate rate"
   end

--- a/lib/framestamp_mixed_rate_arithmatic_error.ex
+++ b/lib/framestamp_mixed_rate_arithmatic_error.ex
@@ -1,0 +1,37 @@
+defmodule Vtc.Framestamp.MixedRateArithmaticError do
+  @moduledoc """
+  Exception returned when mixed-rate arithmatic was attempted without specifying which
+  side of the operation's rate should be inhereted.
+
+  ## Struct Fields
+
+  - `left_rate`: The rate that was found on the left side of the operation.
+
+  - `right_rate`: The rate that was found on the right side of the operation.
+  """
+
+  alias Vtc.Framerate
+
+  @enforce_keys [:func_name, :left_rate, :right_rate]
+  defexception @enforce_keys
+
+  @typedoc """
+  Type of `Framestamp.MixedRateError`.
+  """
+  @type t() :: %__MODULE__{
+          func_name: :add | :sub,
+          left_rate: Framerate.t(),
+          right_rate: Framerate.t()
+        }
+
+  @doc """
+  Returns a message for the error reason.
+  """
+  @spec message(t()) :: String.t()
+  def message(error) do
+    "attempted `Framestamp.#{error.func_name}(a, b)` where `a.rate` does not match" <>
+      " `b.rate`. try `:inheret_rate` option to `:left` or `:right`." <>
+      " alternatively, do your calculation in seconds, then cast back to `Framestamp`" <>
+      " with the appropriate rate"
+  end
+end

--- a/lib/framestamp_parse_error.ex
+++ b/lib/framestamp_parse_error.ex
@@ -34,10 +34,7 @@ defmodule Vtc.Framestamp.ParseError do
   def message(%{reason: :bad_drop_frames}),
     do: "frames value not allowed for drop-frame timecode. frame should have been dropped"
 
-  def message(%{reason: :partial_frame}),
-    do:
-      "`seconds` is not cleanly divisible by `rate.playback`." <>
-        " This check can be turned off by setting `:allow_partial_frames?` to `true`"
+  def message(%{reason: :partial_frame}), do: "`seconds` is not cleanly divisible by `rate.playback`"
 
   def message(%{reason: :drop_frame_maximum_exceeded}), do: "frame number exceeded 24 hours for drop-frame timecode"
 end

--- a/lib/framestamp_range.ex
+++ b/lib/framestamp_range.ex
@@ -411,7 +411,7 @@ defmodule Vtc.Framestamp.Range do
   As `intersection`, but returns a Range from `00:00:00:00` - `00:00:00:00` when there
   is no overlap.
 
-  This returned range inherets the framerate and `out_type` from `a`.
+  This returned range inherits the framerate and `out_type` from `a`.
 
   ## Examples
 
@@ -476,7 +476,7 @@ defmodule Vtc.Framestamp.Range do
   As `separation`, but returns a Range from `00:00:00:00` - `00:00:00:00` when there
   is overlap.
 
-  This returned range inherets the framerate and `out_type` from `a`.
+  This returned range inherits the framerate and `out_type` from `a`.
 
   ## Examples
 

--- a/lib/framestamp_range.ex
+++ b/lib/framestamp_range.ex
@@ -268,7 +268,7 @@ defmodule Vtc.Framestamp.Range do
   defp with_out_type(%{out_type: out_type} = range, out_type), do: range
 
   defp with_out_type(range, :inclusive) do
-    new_out = Framestamp.sub(range.out, 1, round: :off)
+    new_out = Framestamp.sub(range.out, 1)
     %__MODULE__{range | out: new_out, out_type: :inclusive}
   end
 
@@ -280,7 +280,7 @@ defmodule Vtc.Framestamp.Range do
   # Asdjusts an out TC to be an exclusive out.
   @spec adjust_out_exclusive(Framestamp.t(), out_type()) :: Framestamp.t()
   defp adjust_out_exclusive(framestamp, :exclusive), do: framestamp
-  defp adjust_out_exclusive(framestamp, :inclusive), do: Framestamp.add(framestamp, 1, round: :off)
+  defp adjust_out_exclusive(framestamp, :inclusive), do: Framestamp.add(framestamp, 1)
 
   @doc section: :inspect
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -55,6 +55,7 @@ defmodule Vtc.MixProject do
           Convert: &(&1[:section] == :convert),
           Consts: &(&1[:section] == :consts),
           Perfs: &(&1[:section] == :perfs),
+          "Ecto Migrations": &(&1[:section] == :ecto_migrations),
           "Changeset Validations": &(&1[:section] == :changeset_validators),
           Full: &(&1[:section] == :migrations_full),
           "Pg Constraints": &(&1[:section] == :migrations_constraints),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [version]
-target = 0.13
+target = 0.14
 release =
 
 [testing]

--- a/test/ecto/postgres/pg_framerate_test.exs
+++ b/test/ecto/postgres/pg_framerate_test.exs
@@ -30,7 +30,7 @@ defmodule Vtc.Ecto.Postgres.PgFramerateTest do
       },
       %{
         name: "map with playback Ratio",
-        input: %{playback: Ratio.new(24, 1)},
+        input: %{playback: Ratio.new(24)},
         expected: Rates.f24()
       },
       %{

--- a/test/ecto/postgres/pg_framestamp_test.exs
+++ b/test/ecto/postgres/pg_framestamp_test.exs
@@ -908,7 +908,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
   end
 
-  describe "Postgres + (add, no rate inheretence)" do
+  describe "Postgres + (add, no rate inheritence)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
@@ -991,12 +991,12 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
   end
 
-  describe "Postgres @+ (add, left rate inheretence)" do
+  describe "Postgres @+ (add, left rate inheritence)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
     table_test "<%= a %> @+ <%= b %> == <%= expected %>", CommonTables.framestamp_add(), test_case,
-      if: (is_binary(test_case.a) and is_binary(test_case.b)) or Keyword.get(test_case.opts, :inheret_rate) == :left do
+      if: (is_binary(test_case.a) and is_binary(test_case.b)) or Keyword.get(test_case.opts, :inherit_rate) == :left do
       %{a: a, b: b, expected: expected} = test_case
 
       query =
@@ -1021,7 +1021,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
 
         assert {:ok, result} = query |> Repo.one!() |> Framestamp.load()
         assert %Framestamp{} = result
-        assert result == Framestamp.add(a, b, inheret_rate: :left)
+        assert result == Framestamp.add(a, b, inherit_rate: :left)
       end
     end
 
@@ -1035,17 +1035,17 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
             Query.select(query, [r], fragment("(? @+ ?)", r.a, r.b))
           end)
 
-        assert result == Framestamp.add(a, b, inheret_rate: :left)
+        assert result == Framestamp.add(a, b, inherit_rate: :left)
       end
     end
   end
 
-  describe "Postgres +@ (add, right rate inheretence)" do
+  describe "Postgres +@ (add, right rate inheritence)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
     table_test "<%= a %> +@ <%= b %> == <%= expected %>", CommonTables.framestamp_add(), test_case,
-      if: (is_binary(test_case.a) and is_binary(test_case.b)) or Keyword.get(test_case.opts, :inheret_rate) == :right do
+      if: (is_binary(test_case.a) and is_binary(test_case.b)) or Keyword.get(test_case.opts, :inherit_rate) == :right do
       %{a: a, b: b, expected: expected} = test_case
 
       query =
@@ -1070,7 +1070,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
 
         assert {:ok, result} = query |> Repo.one!() |> Framestamp.load()
         assert %Framestamp{} = result
-        assert result == Framestamp.add(a, b, inheret_rate: :right)
+        assert result == Framestamp.add(a, b, inherit_rate: :right)
       end
     end
 
@@ -1084,12 +1084,12 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
             Query.select(query, [r], fragment("(? +@ ?)", r.a, r.b))
           end)
 
-        assert result == Framestamp.add(a, b, inheret_rate: :right)
+        assert result == Framestamp.add(a, b, inherit_rate: :right)
       end
     end
   end
 
-  describe "Postgres - (subtract, no rate inheretence)" do
+  describe "Postgres - (subtract, no rate inheritence)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
@@ -1172,12 +1172,12 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
   end
 
-  describe "Postgres @- (subtract, left rate inheretence)" do
+  describe "Postgres @- (subtract, left rate inheritence)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
     table_test "<%= a %> @- <%= b %> == <%= expected %>", CommonTables.framestamp_subtract(), test_case,
-      if: (is_binary(test_case.a) and is_binary(test_case.b)) or Keyword.get(test_case.opts, :inheret_rate) == :left do
+      if: (is_binary(test_case.a) and is_binary(test_case.b)) or Keyword.get(test_case.opts, :inherit_rate) == :left do
       %{a: a, b: b, expected: expected} = test_case
 
       query =
@@ -1202,7 +1202,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
 
         assert {:ok, result} = query |> Repo.one!() |> Framestamp.load()
         assert %Framestamp{} = result
-        assert result == Framestamp.sub(a, b, inheret_rate: :left)
+        assert result == Framestamp.sub(a, b, inherit_rate: :left)
       end
     end
 
@@ -1216,17 +1216,17 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
             Query.select(query, [r], fragment("(? @- ?)", r.a, r.b))
           end)
 
-        assert result == Framestamp.sub(a, b, inheret_rate: :left)
+        assert result == Framestamp.sub(a, b, inherit_rate: :left)
       end
     end
   end
 
-  describe "Postgres -@ (subtract, right rate inheretence)" do
+  describe "Postgres -@ (subtract, right rate inheritence)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
     table_test "<%= a %> -@ <%= b %> == <%= expected %>", CommonTables.framestamp_subtract(), test_case,
-      if: (is_binary(test_case.a) and is_binary(test_case.b)) or Keyword.get(test_case.opts, :inheret_rate) == :right do
+      if: (is_binary(test_case.a) and is_binary(test_case.b)) or Keyword.get(test_case.opts, :inherit_rate) == :right do
       %{a: a, b: b, expected: expected} = test_case
 
       query =
@@ -1251,7 +1251,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
 
         assert {:ok, result} = query |> Repo.one!() |> Framestamp.load()
         assert %Framestamp{} = result
-        assert result == Framestamp.sub(a, b, inheret_rate: :right)
+        assert result == Framestamp.sub(a, b, inherit_rate: :right)
       end
     end
 
@@ -1265,7 +1265,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
             Query.select(query, [r], fragment("(? -@ ?)", r.a, r.b))
           end)
 
-        assert result == Framestamp.sub(a, b, inheret_rate: :right)
+        assert result == Framestamp.sub(a, b, inherit_rate: :right)
       end
     end
   end

--- a/test/ecto/postgres/pg_framestamp_test.exs
+++ b/test/ecto/postgres/pg_framestamp_test.exs
@@ -908,7 +908,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
   end
 
-  describe "Postgres + (add, no rate inheritence)" do
+  describe "Postgres + (add, no rate inheritance)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
@@ -991,7 +991,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
   end
 
-  describe "Postgres @+ (add, left rate inheritence)" do
+  describe "Postgres @+ (add, left rate inheritance)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
@@ -1040,7 +1040,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
   end
 
-  describe "Postgres +@ (add, right rate inheritence)" do
+  describe "Postgres +@ (add, right rate inheritance)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
@@ -1089,7 +1089,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
   end
 
-  describe "Postgres - (subtract, no rate inheritence)" do
+  describe "Postgres - (subtract, no rate inheritance)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
@@ -1172,7 +1172,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
   end
 
-  describe "Postgres @- (subtract, left rate inheritence)" do
+  describe "Postgres @- (subtract, left rate inheritance)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 
@@ -1221,7 +1221,7 @@ defmodule Vtc.Ecto.Postgres.PgFramestampTest do
     end
   end
 
-  describe "Postgres -@ (subtract, right rate inheritence)" do
+  describe "Postgres -@ (subtract, right rate inheritance)" do
     setup context, do: TestCase.setup_framestamps(context)
     @describetag framestamps: [:a, :b, :expected]
 

--- a/test/ecto/postgres/pg_rational_test.exs
+++ b/test/ecto/postgres/pg_rational_test.exs
@@ -302,7 +302,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     test "can be used on table fields" do
       assert {:ok, %{id: record_id}} =
                %RationalsSchema01{}
-               |> RationalsSchema01.changeset(%{a: Ratio.new(3, 4), b: Ratio.new(1, 1)})
+               |> RationalsSchema01.changeset(%{a: Ratio.new(3, 4), b: Ratio.new(1)})
                |> Repo.insert()
 
       assert {:ok, result} =
@@ -332,7 +332,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     test "can be used on table fields | negative" do
       assert {:ok, %{id: record_id}} =
                %RationalsSchema01{}
-               |> RationalsSchema01.changeset(%{a: Ratio.new(-3, 4), b: Ratio.new(1, 1)})
+               |> RationalsSchema01.changeset(%{a: Ratio.new(-3, 4), b: Ratio.new(1)})
                |> Repo.insert()
 
       assert {:ok, result} =
@@ -348,7 +348,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     test "can be used on table fields | positive" do
       assert {:ok, %{id: record_id}} =
                %RationalsSchema01{}
-               |> RationalsSchema01.changeset(%{a: Ratio.new(3, 4), b: Ratio.new(1, 1)})
+               |> RationalsSchema01.changeset(%{a: Ratio.new(3, 4), b: Ratio.new(1)})
                |> Repo.insert()
 
       assert {:ok, result} =
@@ -403,7 +403,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     test "can be used on table fields" do
       assert {:ok, %{id: record_id}} =
                %RationalsSchema01{}
-               |> RationalsSchema01.changeset(%{a: Ratio.new(3, 4), b: Ratio.new(1, 1)})
+               |> RationalsSchema01.changeset(%{a: Ratio.new(3, 4), b: Ratio.new(1)})
                |> Repo.insert()
 
       result =
@@ -457,7 +457,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     test "can be used on table fields" do
       assert {:ok, %{id: record_id}} =
                %RationalsSchema01{}
-               |> RationalsSchema01.changeset(%{a: Ratio.new(3, 4), b: Ratio.new(1, 1)})
+               |> RationalsSchema01.changeset(%{a: Ratio.new(3, 4), b: Ratio.new(1)})
                |> Repo.insert()
 
       result =
@@ -580,7 +580,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         query =
           Query.from(f in fragment("SELECT DIV(?, ?) as r", type(^a, PgRational), type(^b, PgRational)),
@@ -603,7 +603,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "table fields" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         result =
           run_schema_arithmatic_test(a, b, fn query ->
@@ -619,7 +619,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         query =
           Query.from(f in fragment("SELECT ? / ? as r", type(^a, PgRational), type(^b, PgRational)),
@@ -643,7 +643,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "table fields" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         result =
           run_schema_arithmatic_test(a, b, fn query ->
@@ -659,7 +659,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         expected = Rational.rem(a, b)
 
@@ -686,7 +686,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "table fields" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         result =
           run_schema_arithmatic_test(a, b, fn query ->
@@ -702,7 +702,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         query =
           Query.from(
@@ -748,7 +748,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         query =
           Query.from(f in fragment("SELECT (? = ?) as r", type(^a, PgRational), type(^b, PgRational)),
@@ -798,7 +798,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio using <> operator" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         query = Query.from(f in fragment("SELECT (? <> ?) as r", type(^a, PgRational), type(^b, PgRational)), select: f.r)
         result = Repo.one!(query)
@@ -811,7 +811,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio using != operator" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         query =
           Query.from(
@@ -850,7 +850,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         query =
           Query.from(f in fragment("SELECT (? < ?) as r", type(^a, PgRational), type(^b, PgRational)),
@@ -888,7 +888,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         query =
           Query.from(
@@ -927,7 +927,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         query =
           Query.from(f in fragment("SELECT (? > ?) as r", type(^a, PgRational), type(^b, PgRational)),
@@ -991,7 +991,7 @@ defmodule Vtc.Ecto.Postgres.PgRationalTest do
     property "matches Ratio" do
       check all(
               a <- StreamDataVtc.rational(),
-              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0, 1))))
+              b <- StreamData.filter(StreamDataVtc.rational(), &(not Ratio.eq?(&1, Ratio.new(0))))
             ) do
         query =
           Query.from(

--- a/test/framerate_test.exs
+++ b/test/framerate_test.exs
@@ -12,7 +12,7 @@ defmodule Vtc.FramerateTest do
       %{
         name: "23.98 NTSC",
         inputs: [
-          Ratio.new(24, 1),
+          Ratio.new(24),
           Ratio.new(24_000, 1001),
           24,
           24.0,
@@ -28,12 +28,12 @@ defmodule Vtc.FramerateTest do
         ntsc: :non_drop,
         coerce_ntsc?: true,
         playback: Ratio.new(24_000, 1001),
-        timebase: Ratio.new(24, 1)
+        timebase: Ratio.new(24)
       },
       %{
         name: "29.97 NTSC DF",
         inputs: [
-          Ratio.new(30, 1),
+          Ratio.new(30),
           Ratio.new(30_000, 1001),
           30,
           30.0,
@@ -47,12 +47,12 @@ defmodule Vtc.FramerateTest do
         ntsc: :drop,
         coerce_ntsc?: true,
         playback: Ratio.new(30_000, 1001),
-        timebase: Ratio.new(30, 1)
+        timebase: Ratio.new(30)
       },
       %{
         name: "59.94 NTSC DF",
         inputs: [
-          Ratio.new(60, 1),
+          Ratio.new(60),
           Ratio.new(60_000, 1001),
           60,
           60.0,
@@ -66,7 +66,7 @@ defmodule Vtc.FramerateTest do
         ntsc: :drop,
         coerce_ntsc?: true,
         playback: Ratio.new(60_000, 1001),
-        timebase: Ratio.new(60, 1)
+        timebase: Ratio.new(60)
       },
       %{
         name: "11000/1001 NTSC",
@@ -77,12 +77,12 @@ defmodule Vtc.FramerateTest do
         ntsc: :non_drop,
         coerce_ntsc?: false,
         playback: Ratio.new(11_000, 1001),
-        timebase: Ratio.new(11, 1)
+        timebase: Ratio.new(11)
       },
       %{
         name: "24 fps",
         inputs: [
-          Ratio.new(24, 1),
+          Ratio.new(24),
           24,
           24.0,
           "24/1",
@@ -90,13 +90,13 @@ defmodule Vtc.FramerateTest do
         ],
         ntsc: nil,
         coerce_ntsc?: false,
-        playback: Ratio.new(24, 1),
-        timebase: Ratio.new(24, 1)
+        playback: Ratio.new(24),
+        timebase: Ratio.new(24)
       },
       %{
         name: "error - non-positive | true",
         inputs: [
-          Ratio.new(0, 1),
+          Ratio.new(0),
           Ratio.new(-24, 1),
           0,
           -24,
@@ -146,7 +146,7 @@ defmodule Vtc.FramerateTest do
       %{
         name: "error - bad drop",
         inputs: [
-          Ratio.new(24, 1),
+          Ratio.new(24),
           24,
           "24/1",
           "29"
@@ -273,61 +273,61 @@ defmodule Vtc.FramerateTest do
         const: Rates.f23_98(),
         ntsc: :non_drop,
         playback: Ratio.new(24_000, 1001),
-        timebase: Ratio.new(24, 1)
+        timebase: Ratio.new(24)
       },
       %{
         const: Rates.f24(),
         ntsc: nil,
-        playback: Ratio.new(24, 1),
-        timebase: Ratio.new(24, 1)
+        playback: Ratio.new(24),
+        timebase: Ratio.new(24)
       },
       %{
         const: Rates.f29_97_ndf(),
         ntsc: :non_drop,
         playback: Ratio.new(30_000, 1001),
-        timebase: Ratio.new(30, 1)
+        timebase: Ratio.new(30)
       },
       %{
         const: Rates.f29_97_df(),
         ntsc: :drop,
         playback: Ratio.new(30_000, 1001),
-        timebase: Ratio.new(30, 1)
+        timebase: Ratio.new(30)
       },
       %{
         const: Rates.f30(),
         ntsc: nil,
-        playback: Ratio.new(30, 1),
-        timebase: Ratio.new(30, 1)
+        playback: Ratio.new(30),
+        timebase: Ratio.new(30)
       },
       %{
         const: Rates.f47_95(),
         ntsc: :non_drop,
         playback: Ratio.new(48_000, 1001),
-        timebase: Ratio.new(48, 1)
+        timebase: Ratio.new(48)
       },
       %{
         const: Rates.f48(),
         ntsc: nil,
-        playback: Ratio.new(48, 1),
-        timebase: Ratio.new(48, 1)
+        playback: Ratio.new(48),
+        timebase: Ratio.new(48)
       },
       %{
         const: Rates.f59_94_ndf(),
         ntsc: :non_drop,
         playback: Ratio.new(60_000, 1001),
-        timebase: Ratio.new(60, 1)
+        timebase: Ratio.new(60)
       },
       %{
         const: Rates.f59_94_df(),
         ntsc: :drop,
         playback: Ratio.new(60_000, 1001),
-        timebase: Ratio.new(60, 1)
+        timebase: Ratio.new(60)
       },
       %{
         const: Rates.f60(),
         ntsc: nil,
-        playback: Ratio.new(60, 1),
-        timebase: Ratio.new(60, 1)
+        playback: Ratio.new(60),
+        timebase: Ratio.new(60)
       }
     ]
 

--- a/test/framestamp/framestamp_ops_test.exs
+++ b/test/framestamp/framestamp_ops_test.exs
@@ -275,31 +275,31 @@ defmodule Vtc.FramestampTest.Ops do
     end
 
     table_test "<%= a %> + <%= b %> == <%= expected %> | opts: <%= opts %> | flipped", add_table, test_case,
-      if: not Keyword.has_key?(test_case.opts, :inheret_rate) do
+      if: not Keyword.has_key?(test_case.opts, :inherit_rate) do
       %{a: a, b: b, opts: opts, expected: expected} = test_case
       assert Framestamp.add(b, a, opts) == expected
     end
 
-    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inheret_rate: false]", add_table, test_case,
+    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inherit_rate: false]", add_table, test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, opts: opts, expected: expected} = test_case
-      opts = Keyword.put(opts, :inheret_rate, false)
+      opts = Keyword.put(opts, :inherit_rate, false)
 
       assert Framestamp.add(b, a, opts) == expected
     end
 
-    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inheret_rate: :left]", add_table, test_case,
+    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inherit_rate: :left]", add_table, test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, opts: opts, expected: expected} = test_case
-      opts = Keyword.put(opts, :inheret_rate, :left)
+      opts = Keyword.put(opts, :inherit_rate, :left)
 
       assert Framestamp.add(b, a, opts) == expected
     end
 
-    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inheret_rate: :right]", add_table, test_case,
+    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inherit_rate: :right]", add_table, test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, opts: opts, expected: expected} = test_case
-      opts = Keyword.put(opts, :inheret_rate, :right)
+      opts = Keyword.put(opts, :inherit_rate, :right)
 
       assert Framestamp.add(b, a, opts) == expected
     end
@@ -465,7 +465,7 @@ defmodule Vtc.FramestampTest.Ops do
 
       assert Framestamp.MixedRateArithmaticError.message(error) ==
                "attempted `Framestamp.add(a, b)` where `a.rate` does not match `b.rate`." <>
-                 " try `:inheret_rate` option to `:left` or `:right`. alternatively," <>
+                 " try `:inherit_rate` option to `:left` or `:right`. alternatively," <>
                  " do your calculation in seconds, then cast back to `Framestamp` with" <>
                  " the appropriate rate"
     end
@@ -483,26 +483,26 @@ defmodule Vtc.FramestampTest.Ops do
       assert Framestamp.sub(a, b, opts) == expected
     end
 
-    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inheret_rate: false]", sub_table, test_case,
+    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inherit_rate: false]", sub_table, test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, opts: opts, expected: expected} = test_case
-      opts = Keyword.put(opts, :inheret_rate, false)
+      opts = Keyword.put(opts, :inherit_rate, false)
 
       assert Framestamp.sub(a, b, opts) == expected
     end
 
-    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inheret_rate: :left]", sub_table, test_case,
+    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inherit_rate: :left]", sub_table, test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, opts: opts, expected: expected} = test_case
-      opts = Keyword.put(opts, :inheret_rate, :left)
+      opts = Keyword.put(opts, :inherit_rate, :left)
 
       assert Framestamp.sub(a, b, opts) == expected
     end
 
-    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inheret_rate: :right]", sub_table, test_case,
+    table_test "<%= a %> + <%= b %> == <%= expected %> | opts: [inherit_rate: :right]", sub_table, test_case,
       if: is_binary(test_case.a) and is_binary(test_case.b) do
       %{a: a, b: b, opts: opts, expected: expected} = test_case
-      opts = Keyword.put(opts, :inheret_rate, :right)
+      opts = Keyword.put(opts, :inherit_rate, :right)
 
       assert Framestamp.sub(a, b, opts) == expected
     end
@@ -661,7 +661,7 @@ defmodule Vtc.FramestampTest.Ops do
 
       assert Framestamp.MixedRateArithmaticError.message(error) ==
                "attempted `Framestamp.sub(a, b)` where `a.rate` does not match `b.rate`." <>
-                 " try `:inheret_rate` option to `:left` or `:right`. alternatively," <>
+                 " try `:inherit_rate` option to `:left` or `:right`. alternatively," <>
                  " do your calculation in seconds, then cast back to `Framestamp` with" <>
                  " the appropriate rate"
     end

--- a/test/framestamp/framestamp_property_test.exs
+++ b/test/framestamp/framestamp_property_test.exs
@@ -268,7 +268,7 @@ defmodule Vtc.FramestampTest.Properties.Arithmetic do
               a <-
                 StreamData.filter(
                   StreamDataVtc.framestamp(rate_opts: [type: [:whole, :drop, :non_drop]]),
-                  &Ratio.gt?(&1.rate.playback, Ratio.new(1, 1))
+                  &Ratio.gt?(&1.rate.playback, Ratio.new(1))
                 ),
               multiplier <- float()
             ) do
@@ -303,7 +303,7 @@ defmodule Vtc.FramestampTest.Properties.Arithmetic do
               a <-
                 StreamData.filter(
                   StreamDataVtc.framestamp(rate_opts: [type: [:whole, :drop, :non_drop]]),
-                  &Ratio.gt?(&1.rate.playback, Ratio.new(1, 1))
+                  &Ratio.gt?(&1.rate.playback, Ratio.new(1))
                 ),
               multiplier <- filter(float(), &(&1 != 0))
             ) do

--- a/test/range_test.exs
+++ b/test/range_test.exs
@@ -636,7 +636,7 @@ defmodule Vtc.Framestamp.RangeTest do
       assert Range.intersection(b, a) == expected
     end
 
-    test "inherets a's rate in mixed rate operations" do
+    test "inherits a's rate in mixed rate operations" do
       a = TestCase.setup_range({"01:00:00:00", "02:00:00:00", Rates.f23_98()})
       b = TestCase.setup_range({"01:00:00:00", "02:00:00:00", Rates.f47_95()})
       expected = TestCase.setup_range({"01:00:00:00", "02:00:00:00", Rates.f23_98()})
@@ -645,7 +645,7 @@ defmodule Vtc.Framestamp.RangeTest do
       assert result == expected
     end
 
-    test "inherets a's out_type in mixed type operations" do
+    test "inherits a's out_type in mixed type operations" do
       a = {"01:00:00:00", "02:00:00:00"} |> TestCase.setup_range() |> Range.with_inclusive_out()
       b = TestCase.setup_range({"01:00:00:00", "02:00:00:00"})
       expected = {"01:00:00:00", "02:00:00:00"} |> TestCase.setup_range() |> Range.with_inclusive_out()
@@ -681,7 +681,7 @@ defmodule Vtc.Framestamp.RangeTest do
       assert Range.intersection!(a, b) == expected
     end
 
-    test "zero-length inherets a's rate in mixed rate operations" do
+    test "zero-length inherits a's rate in mixed rate operations" do
       a = TestCase.setup_range({"01:00:00:00", "02:00:00:00", Rates.f47_95()})
       b = TestCase.setup_range({"03:00:00:00", "04:00:00:00", Rates.f23_98()})
 
@@ -689,7 +689,7 @@ defmodule Vtc.Framestamp.RangeTest do
       assert Range.intersection!(a, b) == expected
     end
 
-    test "zero-length inherets a's out_type" do
+    test "zero-length inherits a's out_type" do
       a = {"01:00:00:00", "02:00:00:00"} |> TestCase.setup_range() |> Range.with_inclusive_out()
       b = TestCase.setup_range({"03:00:00:00", "04:00:00:00"})
 
@@ -771,7 +771,7 @@ defmodule Vtc.Framestamp.RangeTest do
       assert Range.separation(b, a) == expected
     end
 
-    test "inherets a's rate in mixed rate operations" do
+    test "inherits a's rate in mixed rate operations" do
       a = TestCase.setup_range({"01:00:00:00", "02:00:00:00", Rates.f23_98()})
       b = TestCase.setup_range({"03:00:00:00", "04:00:00:00", Rates.f47_95()})
       expected = TestCase.setup_range({"02:00:00:00", "03:00:00:00", Rates.f23_98()})
@@ -780,7 +780,7 @@ defmodule Vtc.Framestamp.RangeTest do
       assert result == expected
     end
 
-    test "inherets a's out_type in mixed type operations" do
+    test "inherits a's out_type in mixed type operations" do
       a = {"01:00:00:00", "02:00:00:00"} |> TestCase.setup_range() |> Range.with_inclusive_out()
       b = TestCase.setup_range({"03:00:00:00", "04:00:00:00"})
       expected = {"02:00:00:00", "03:00:00:00"} |> TestCase.setup_range() |> Range.with_inclusive_out()
@@ -816,7 +816,7 @@ defmodule Vtc.Framestamp.RangeTest do
       assert Range.separation!(a, b) == expected
     end
 
-    test "zero-length inherets a's rate in mixed rate operations" do
+    test "zero-length inherits a's rate in mixed rate operations" do
       a = TestCase.setup_range({"01:00:00:00", "02:00:00:00", Rates.f47_95()})
       b = TestCase.setup_range({"01:00:00:00", "02:00:00:00", Rates.f23_98()})
 
@@ -824,7 +824,7 @@ defmodule Vtc.Framestamp.RangeTest do
       assert Range.separation!(a, b) == expected
     end
 
-    test "zero-length inherets a's out_type" do
+    test "zero-length inherits a's out_type" do
       a = {"01:00:00:00", "02:00:00:00"} |> TestCase.setup_range() |> Range.with_inclusive_out()
       b = TestCase.setup_range({"01:00:00:00", "02:00:00:00"})
 

--- a/test/support/common_tables.ex
+++ b/test/support/common_tables.ex
@@ -183,25 +183,25 @@ defmodule Vtc.Test.Support.CommonTables do
       %{
         a: {"01:00:00:00", Rates.f23_98()},
         b: {"01:00:00:00", Rates.f47_95()},
-        opts: [inheret_rate: :left],
+        opts: [inherit_rate: :left],
         expected: {"02:00:00:00", Rates.f23_98()}
       },
       %{
         a: {"01:00:00:00", Rates.f23_98()},
         b: {"01:00:00:00", Rates.f47_95()},
-        opts: [inheret_rate: :right],
+        opts: [inherit_rate: :right],
         expected: {"02:00:00:00", Rates.f47_95()}
       },
       %{
         a: {"01:00:00:00", Rates.f23_98()},
         b: {"00:00:00:02", Rates.f47_95()},
-        opts: [inheret_rate: :left],
+        opts: [inherit_rate: :left],
         expected: {"01:00:00:01", Rates.f23_98()}
       },
       %{
         a: {"01:00:00:00", Rates.f23_98()},
         b: {"00:00:00:02", Rates.f47_95()},
-        opts: [inheret_rate: :right],
+        opts: [inherit_rate: :right],
         expected: {"01:00:00:02", Rates.f47_95()}
       }
     ]
@@ -247,25 +247,25 @@ defmodule Vtc.Test.Support.CommonTables do
       %{
         a: {"02:00:00:00", Rates.f23_98()},
         b: {"01:00:00:00", Rates.f47_95()},
-        opts: [inheret_rate: :left],
+        opts: [inherit_rate: :left],
         expected: {"01:00:00:00", Rates.f23_98()}
       },
       %{
         a: {"02:00:00:00", Rates.f23_98()},
         b: {"01:00:00:00", Rates.f47_95()},
-        opts: [inheret_rate: :right],
+        opts: [inherit_rate: :right],
         expected: {"01:00:00:00", Rates.f47_95()}
       },
       %{
         a: {"01:00:00:02", Rates.f23_98()},
         b: {"00:00:00:02", Rates.f47_95()},
-        opts: [inheret_rate: :left],
+        opts: [inherit_rate: :left],
         expected: {"01:00:00:01", Rates.f23_98()}
       },
       %{
         a: {"01:00:00:02", Rates.f23_98()},
         b: {"00:00:00:02", Rates.f47_95()},
-        opts: [inheret_rate: :right],
+        opts: [inherit_rate: :right],
         expected: {"01:00:00:02", Rates.f47_95()}
       }
     ]

--- a/test/support/common_tables.ex
+++ b/test/support/common_tables.ex
@@ -153,37 +153,56 @@ defmodule Vtc.Test.Support.CommonTables do
       %{
         a: "01:00:00:00",
         b: "01:00:00:00",
+        opts: [],
         expected: "02:00:00:00"
       },
       %{
         a: "01:00:00:00",
         b: "00:00:00:00",
+        opts: [],
         expected: "01:00:00:00"
       },
       %{
         a: "01:00:00:00",
         b: "-01:00:00:00",
+        opts: [],
         expected: "00:00:00:00"
       },
       %{
         a: "01:00:00:00",
         b: "-02:00:00:00",
+        opts: [],
         expected: "-01:00:00:00"
       },
       %{
         a: "10:12:13:14",
         b: "14:13:12:11",
+        opts: [],
         expected: "24:25:26:01"
       },
       %{
         a: {"01:00:00:00", Rates.f23_98()},
         b: {"01:00:00:00", Rates.f47_95()},
+        opts: [inheret_rate: :left],
         expected: {"02:00:00:00", Rates.f23_98()}
       },
       %{
         a: {"01:00:00:00", Rates.f23_98()},
+        b: {"01:00:00:00", Rates.f47_95()},
+        opts: [inheret_rate: :right],
+        expected: {"02:00:00:00", Rates.f47_95()}
+      },
+      %{
+        a: {"01:00:00:00", Rates.f23_98()},
         b: {"00:00:00:02", Rates.f47_95()},
+        opts: [inheret_rate: :left],
         expected: {"01:00:00:01", Rates.f23_98()}
+      },
+      %{
+        a: {"01:00:00:00", Rates.f23_98()},
+        b: {"00:00:00:02", Rates.f47_95()},
+        opts: [inheret_rate: :right],
+        expected: {"01:00:00:02", Rates.f47_95()}
       }
     ]
   end
@@ -198,37 +217,56 @@ defmodule Vtc.Test.Support.CommonTables do
       %{
         a: "01:00:00:00",
         b: "01:00:00:00",
+        opts: [],
         expected: "00:00:00:00"
       },
       %{
         a: "01:00:00:00",
         b: "00:00:00:00",
+        opts: [],
         expected: "01:00:00:00"
       },
       %{
         a: "01:00:00:00",
         b: "-01:00:00:00",
+        opts: [],
         expected: "02:00:00:00"
       },
       %{
         a: "01:00:00:00",
         b: "02:00:00:00",
+        opts: [],
         expected: "-01:00:00:00"
       },
       %{
         a: "34:10:09:08",
         b: "10:06:07:14",
+        opts: [],
         expected: "24:04:01:18"
       },
       %{
         a: {"02:00:00:00", Rates.f23_98()},
         b: {"01:00:00:00", Rates.f47_95()},
+        opts: [inheret_rate: :left],
         expected: {"01:00:00:00", Rates.f23_98()}
+      },
+      %{
+        a: {"02:00:00:00", Rates.f23_98()},
+        b: {"01:00:00:00", Rates.f47_95()},
+        opts: [inheret_rate: :right],
+        expected: {"01:00:00:00", Rates.f47_95()}
       },
       %{
         a: {"01:00:00:02", Rates.f23_98()},
         b: {"00:00:00:02", Rates.f47_95()},
+        opts: [inheret_rate: :left],
         expected: {"01:00:00:01", Rates.f23_98()}
+      },
+      %{
+        a: {"01:00:00:02", Rates.f23_98()},
+        b: {"00:00:00:02", Rates.f47_95()},
+        opts: [inheret_rate: :right],
+        expected: {"01:00:00:02", Rates.f47_95()}
       }
     ]
   end

--- a/zdocs/ecto_quickstart.cheatmd
+++ b/zdocs/ecto_quickstart.cheatmd
@@ -322,3 +322,70 @@ Output:
   86400
 (1 row)
 ```
+
+## Framestamp Postgres operators
+
+#### Available operators
+| name  | type     | args                       | result        | description                                    |
+| ----- | -------- | -------------------------- | ------------- | ---------------------------------------------- |
+| `=`   | operator | `framestamp`, `framestamp` |  `boolean`    |  true if `a` seconds == `b` seconds            |
+| `<`   | operator | `framestamp`, `framestamp` |  `boolean`    |  true if `a` seconds < `b` seconds             |
+| `<=`  | operator | `framestamp`, `framestamp` |  `boolean`    |  true if `a` seconds <= `b` seconds            |
+| `>`   | operator | `framestamp`, `framestamp` |  `boolean`    |  true if `a` seconds > `b` seconds             |
+| `>=`  | operator | `framestamp`, `framestamp` |  `boolean`    |  true if `a` seconds >= `b` seconds            |
+| `+`   | operator | `framestamp`, `framestamp` |  `framestamp` |  addition, raises if framerates do not match   |
+| `@+`  | operator | `framestamp`, `framestamp` |  `framestamp` |  addition, inherit framerate from left         |
+| `+@`  | operator | `framestamp`, `framestamp` |  `framestamp` |  addition, inherit framerate from right        |
+| `-`   | operator | `framestamp`, `framestamp` |  `framestamp` |  subtration, raises if framerates do not match |
+| `@-`  | operator | `framestamp`, `framestamp` |  `framestamp` |  subtration, inherit framerate from left       |
+| `-@`  | operator | `framestamp`, `framestamp` |  `framestamp` |  subtration, inherit framerate from right      |
+| `*`   | operator | `framestamp`, `rational`   |  `framestamp` |  multiplication, rounds to nearest whole-frame |
+| `/`   | operator | `framestamp`, `rational`   |  `framestamp` |  division, rounds to nearest frame             |
+| `DIV` | function | `framestamp`, `rational`   |  `framestamp` |  floor-division, rounds down to nearest frame  |
+| `%`   | operator | `framestamp`, `rational`   |  `framestamp` |  remainder, returns leftover frames from `DIV` |
+.
+
+### Mixed rate arithmatic
+
+{: .col-2}
+
+#### Elixir
+```elixir
+iex> a = Framestamp.with_frames!("01:00:00:00", Rates.f23_98())
+iex> b = Framestamp.with_frames!("01:00:00:00", Rates.f47_95())
+iex> 
+iex> query =
+iex>   Query.from(
+iex>     f in fragment(
+iex>       "SELECT "? +@ ? as r",
+iex>       type(^a, Framestamp),
+iex>       type(^b, Framestamp)
+iex>     ),
+iex>     select: f.r
+iex>   )
+iex> 
+iex> Repo.one!(query) |> Framestamp.load() |> inspect()
+"{:ok, <02:00:00:00 <47.95 NTSC>>}"
+```
+
+#### SQL
+```sql
+SELECT
+  (
+    (18018, 5)::rational,
+    ((24000, 1001), '{non_drop}')::framerate
+  )::framestamp
+  +@ (
+    (18018, 5)::rational,
+    ((48000, 1001), '{non_drop}')::framerate
+  )::framestamp;
+```
+
+Output:
+
+```text
+                   ?column?
+-----------------------------------------------
+ ("(36036,5)","(""(48000,1001)"",{non_drop})")
+(1 row)
+```


### PR DESCRIPTION
## CHANGES

- Makes the way that framerates are inherited in mixed-rate calculations configurable.

    - Adds `:inherit_rate` opt to `Framestamp.add/3` and `Framestamp.sub/3`
    - Adds `@+` Postgres operator to flag the the left rate should be inherited
    - Adds `+@` Postgres operator to flag the the right rate should be inherited
    - Adds `@-` Postgres operator to flag the the left rate should be inherited
    - Adds `-@` Postgres operator to flag the the right rate should be inherited
    - Mixed rate add/subtract operations now throw errors when if inheritance is not configured.

- The `:off` rounding option now always throws if the `seconds` value does not result in a whole-frame.
- Updates Ecto quickstart
- Bumps minor version