### PR TITLE
[Feature] Add minus and ABS functions / operators

### DIFF
--- a/lib/framestamp_range.ex
+++ b/lib/framestamp_range.ex
@@ -619,7 +619,7 @@ defmodule Vtc.Framestamp.Range do
   end
 
   # Runs a calculation, converting any ranges in `args` to exclusive out points then,
-  # if the result is also a range, casting it's out point to the same type as the first
+  # if the result is also a range, casting its out point to the same type as the first
   # Range argument in `args`.
   @spec calc_with_exclusive([t()], Framestamp.inherit_opt(), atom(), (... -> result)) :: result when result: any()
   defp calc_with_exclusive(args, inherit_opt, func_name, calc) do

--- a/zdocs/ecto_quickstart.cheatmd
+++ b/zdocs/ecto_quickstart.cheatmd
@@ -330,16 +330,19 @@ Output:
 | `<=`  | operator | `framestamp`, `framestamp` |  `boolean`    |  true if `a` seconds <= `b` seconds             |
 | `>`   | operator | `framestamp`, `framestamp` |  `boolean`    |  true if `a` seconds > `b` seconds              |
 | `>=`  | operator | `framestamp`, `framestamp` |  `boolean`    |  true if `a` seconds >= `b` seconds             |
-| `+`   | operator | `framestamp`, `framestamp` |  `framestamp` |  addition, raises if framerates do not match    |
-| `@+`  | operator | `framestamp`, `framestamp` |  `framestamp` |  addition, inherit framerate from left          |
-| `+@`  | operator | `framestamp`, `framestamp` |  `framestamp` |  addition, inherit framerate from right         |
-| `-`   | operator | `framestamp`, `framestamp` |  `framestamp` |  subtraction, raises if framerates do not match |
-| `@-`  | operator | `framestamp`, `framestamp` |  `framestamp` |  subtraction, inherit framerate from left       |
-| `-@`  | operator | `framestamp`, `framestamp` |  `framestamp` |  subtraction, inherit framerate from right      |
-| `*`   | operator | `framestamp`, `rational`   |  `framestamp` |  multiplication, rounds to nearest whole-frame  |
-| `/`   | operator | `framestamp`, `rational`   |  `framestamp` |  division, rounds to nearest frame              |
-| `DIV` | function | `framestamp`, `rational`   |  `framestamp` |  floor-division, rounds down to nearest frame   |
-| `%`   | operator | `framestamp`, `rational`   |  `framestamp` |  remainder, returns leftover frames from `DIV`  |
+| `ABS` | function | `framestamp`               |  `framestamp` |  absolute value                                 |
+| `@`   | operator | `framestamp`               |  `framestamp` |  absolute value                                 |
+| `-`   | function | `framestamp`               |  `framestamp` |  negate. flips input's sign                     |
+| `+`   | operator | `framestamp`, `framestamp` |  `framestamp` |  addition. raises if framerates do not match    |
+| `@+`  | operator | `framestamp`, `framestamp` |  `framestamp` |  addition. inherit framerate from left          |
+| `+@`  | operator | `framestamp`, `framestamp` |  `framestamp` |  addition. inherit framerate from right         |
+| `-`   | operator | `framestamp`, `framestamp` |  `framestamp` |  subtraction. raises if framerates do not match |
+| `@-`  | operator | `framestamp`, `framestamp` |  `framestamp` |  subtraction. inherit framerate from left       |
+| `-@`  | operator | `framestamp`, `framestamp` |  `framestamp` |  subtraction. inherit framerate from right      |
+| `*`   | operator | `framestamp`, `rational`   |  `framestamp` |  multiplication. rounds to nearest whole-frame  |
+| `/`   | operator | `framestamp`, `rational`   |  `framestamp` |  division. rounds to nearest frame              |
+| `DIV` | function | `framestamp`, `rational`   |  `framestamp` |  floor-division. rounds down to nearest frame   |
+| `%`   | operator | `framestamp`, `rational`   |  `framestamp` |  remainder. returns leftover frames from `DIV`  |
 .
 
 ### Mixed rate arithmetic


### PR DESCRIPTION
- Adds `-` unary `framestamp` operator that negates timecode values.
- Adds `ABS/1` function overload for `framestamp` that returns the absolute value of a framestamp.
- Adds `@` unary `framestamp` operator that returns the absolute value of the input.

See Postgres docs for `ABS` and `@` [here](https://www.postgresql.org/docs/9.5/functions-math.html). Unary `-` does not seem to be documented but can be trivially observed with statements like `SELECT -(2 + 4)` and `SELECT -(2 - 4)`.